### PR TITLE
スペルタイマーにアイコンを表示する機能を追加しました

### DIFF
--- a/ACT.SpecialSpellTimer/ConfigPanel.Designer.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.Designer.cs
@@ -42,6 +42,8 @@
             this.DetailGroupBox = new System.Windows.Forms.GroupBox();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.OverlapRecastTimeCheckBox = new System.Windows.Forms.CheckBox();
+            this.HideSpellNameCheckBox = new System.Windows.Forms.CheckBox();
             this.SpellIconSizeUpDown = new System.Windows.Forms.NumericUpDown();
             this.label61 = new System.Windows.Forms.Label();
             this.SpellIconComboBox = new System.Windows.Forms.ComboBox();
@@ -59,6 +61,7 @@
             this.ExpandSecounds1NumericUpDown = new System.Windows.Forms.NumericUpDown();
             this.KeywordToExpand1TextBox = new System.Windows.Forms.TextBox();
             this.label50 = new System.Windows.Forms.Label();
+            this.SpellVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
             this.RegexEnabledCheckBox = new System.Windows.Forms.CheckBox();
             this.DontHideCheckBox = new System.Windows.Forms.CheckBox();
             this.label27 = new System.Windows.Forms.Label();
@@ -119,6 +122,7 @@
             this.OnPointTelopTabPage = new System.Windows.Forms.TabPage();
             this.TelopDetailGroupBox = new System.Windows.Forms.GroupBox();
             this.TelopSelectZoneButton = new System.Windows.Forms.Button();
+            this.TelopVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
             this.TelopSelectJobButton = new System.Windows.Forms.Button();
             this.TelopProgressBarEnabledCheckBox = new System.Windows.Forms.CheckBox();
             this.EnabledAddMessageCheckBox = new System.Windows.Forms.CheckBox();
@@ -221,14 +225,12 @@
             this.label18 = new System.Windows.Forms.Label();
             this.SwitchOverlayButton = new System.Windows.Forms.Button();
             this.ShokikaButton = new System.Windows.Forms.Button();
+            this.DefaultVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
             this.OpenFileDialog = new System.Windows.Forms.OpenFileDialog();
             this.SaveFileDialog = new System.Windows.Forms.SaveFileDialog();
             this.ToolTip = new System.Windows.Forms.ToolTip(this.components);
             this.CombatAnalyzingTimer = new System.Windows.Forms.Timer(this.components);
             this.EnabledSpellTimerNoDecimal = new System.Windows.Forms.CheckBox();
-            this.SpellVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
-            this.TelopVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
-            this.DefaultVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
             this.TabControl.SuspendLayout();
             this.SpecialSpellTabPage.SuspendLayout();
             this.DetailPanelGroupBox.SuspendLayout();
@@ -430,6 +432,8 @@
             // 
             // tabPage1
             // 
+            this.tabPage1.Controls.Add(this.OverlapRecastTimeCheckBox);
+            this.tabPage1.Controls.Add(this.HideSpellNameCheckBox);
             this.tabPage1.Controls.Add(this.SpellIconSizeUpDown);
             this.tabPage1.Controls.Add(this.label61);
             this.tabPage1.Controls.Add(this.SpellIconComboBox);
@@ -471,6 +475,26 @@
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "GeneralTab";
             this.tabPage1.UseVisualStyleBackColor = true;
+            // 
+            // OverlapRecastTimeCheckBox
+            // 
+            this.OverlapRecastTimeCheckBox.AutoSize = true;
+            this.OverlapRecastTimeCheckBox.Location = new System.Drawing.Point(519, 355);
+            this.OverlapRecastTimeCheckBox.Name = "OverlapRecastTimeCheckBox";
+            this.OverlapRecastTimeCheckBox.Size = new System.Drawing.Size(176, 16);
+            this.OverlapRecastTimeCheckBox.TabIndex = 71;
+            this.OverlapRecastTimeCheckBox.Text = "OverlapRecastTimeCheckBox";
+            this.OverlapRecastTimeCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // HideSpellNameCheckBox
+            // 
+            this.HideSpellNameCheckBox.AutoSize = true;
+            this.HideSpellNameCheckBox.Location = new System.Drawing.Point(519, 333);
+            this.HideSpellNameCheckBox.Name = "HideSpellNameCheckBox";
+            this.HideSpellNameCheckBox.Size = new System.Drawing.Size(153, 16);
+            this.HideSpellNameCheckBox.TabIndex = 70;
+            this.HideSpellNameCheckBox.Text = "HideSpellNameCheckBox";
+            this.HideSpellNameCheckBox.UseVisualStyleBackColor = true;
             // 
             // SpellIconSizeUpDown
             // 
@@ -663,6 +687,20 @@
             this.label50.Size = new System.Drawing.Size(171, 12);
             this.label50.TabIndex = 52;
             this.label50.Text = "MatchingLogWordToExpandLabel";
+            // 
+            // SpellVisualSetting
+            // 
+            this.SpellVisualSetting.BackgroundColor = System.Drawing.Color.Empty;
+            this.SpellVisualSetting.BarColor = System.Drawing.Color.White;
+            this.SpellVisualSetting.BarEnabled = true;
+            this.SpellVisualSetting.BarOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
+            this.SpellVisualSetting.BarSize = new System.Drawing.Size(190, 8);
+            this.SpellVisualSetting.FontColor = System.Drawing.Color.White;
+            this.SpellVisualSetting.FontOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
+            this.SpellVisualSetting.Location = new System.Drawing.Point(195, 262);
+            this.SpellVisualSetting.Name = "SpellVisualSetting";
+            this.SpellVisualSetting.Size = new System.Drawing.Size(306, 71);
+            this.SpellVisualSetting.TabIndex = 51;
             // 
             // RegexEnabledCheckBox
             // 
@@ -1322,6 +1360,20 @@
             this.TelopSelectZoneButton.TabIndex = 46;
             this.TelopSelectZoneButton.Text = "SelectZoneButton";
             this.TelopSelectZoneButton.UseVisualStyleBackColor = true;
+            // 
+            // TelopVisualSetting
+            // 
+            this.TelopVisualSetting.BackgroundColor = System.Drawing.Color.Empty;
+            this.TelopVisualSetting.BarColor = System.Drawing.Color.White;
+            this.TelopVisualSetting.BarEnabled = false;
+            this.TelopVisualSetting.BarOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
+            this.TelopVisualSetting.BarSize = new System.Drawing.Size(190, 8);
+            this.TelopVisualSetting.FontColor = System.Drawing.Color.White;
+            this.TelopVisualSetting.FontOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
+            this.TelopVisualSetting.Location = new System.Drawing.Point(187, 143);
+            this.TelopVisualSetting.Name = "TelopVisualSetting";
+            this.TelopVisualSetting.Size = new System.Drawing.Size(306, 71);
+            this.TelopVisualSetting.TabIndex = 6;
             // 
             // TelopSelectJobButton
             // 
@@ -2371,6 +2423,20 @@
             this.ShokikaButton.UseVisualStyleBackColor = true;
             this.ShokikaButton.Click += new System.EventHandler(this.ShokikaButton_Click);
             // 
+            // DefaultVisualSetting
+            // 
+            this.DefaultVisualSetting.BackgroundColor = System.Drawing.Color.Empty;
+            this.DefaultVisualSetting.BarColor = System.Drawing.Color.White;
+            this.DefaultVisualSetting.BarEnabled = true;
+            this.DefaultVisualSetting.BarOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
+            this.DefaultVisualSetting.BarSize = new System.Drawing.Size(190, 8);
+            this.DefaultVisualSetting.FontColor = System.Drawing.Color.White;
+            this.DefaultVisualSetting.FontOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
+            this.DefaultVisualSetting.Location = new System.Drawing.Point(293, 108);
+            this.DefaultVisualSetting.Name = "DefaultVisualSetting";
+            this.DefaultVisualSetting.Size = new System.Drawing.Size(306, 71);
+            this.DefaultVisualSetting.TabIndex = 37;
+            // 
             // OpenFileDialog
             // 
             this.OpenFileDialog.DefaultExt = "xml";
@@ -2402,48 +2468,6 @@
             this.EnabledSpellTimerNoDecimal.TabIndex = 42;
             this.EnabledSpellTimerNoDecimal.Text = "Enabled";
             this.EnabledSpellTimerNoDecimal.UseVisualStyleBackColor = true;
-            // 
-            // SpellVisualSetting
-            // 
-            this.SpellVisualSetting.BackgroundColor = System.Drawing.Color.Empty;
-            this.SpellVisualSetting.BarColor = System.Drawing.Color.White;
-            this.SpellVisualSetting.BarEnabled = true;
-            this.SpellVisualSetting.BarOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
-            this.SpellVisualSetting.BarSize = new System.Drawing.Size(190, 8);
-            this.SpellVisualSetting.FontColor = System.Drawing.Color.White;
-            this.SpellVisualSetting.FontOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
-            this.SpellVisualSetting.Location = new System.Drawing.Point(195, 262);
-            this.SpellVisualSetting.Name = "SpellVisualSetting";
-            this.SpellVisualSetting.Size = new System.Drawing.Size(306, 71);
-            this.SpellVisualSetting.TabIndex = 51;
-            // 
-            // TelopVisualSetting
-            // 
-            this.TelopVisualSetting.BackgroundColor = System.Drawing.Color.Empty;
-            this.TelopVisualSetting.BarColor = System.Drawing.Color.White;
-            this.TelopVisualSetting.BarEnabled = false;
-            this.TelopVisualSetting.BarOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
-            this.TelopVisualSetting.BarSize = new System.Drawing.Size(190, 8);
-            this.TelopVisualSetting.FontColor = System.Drawing.Color.White;
-            this.TelopVisualSetting.FontOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
-            this.TelopVisualSetting.Location = new System.Drawing.Point(187, 143);
-            this.TelopVisualSetting.Name = "TelopVisualSetting";
-            this.TelopVisualSetting.Size = new System.Drawing.Size(306, 71);
-            this.TelopVisualSetting.TabIndex = 6;
-            // 
-            // DefaultVisualSetting
-            // 
-            this.DefaultVisualSetting.BackgroundColor = System.Drawing.Color.Empty;
-            this.DefaultVisualSetting.BarColor = System.Drawing.Color.White;
-            this.DefaultVisualSetting.BarEnabled = true;
-            this.DefaultVisualSetting.BarOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
-            this.DefaultVisualSetting.BarSize = new System.Drawing.Size(190, 8);
-            this.DefaultVisualSetting.FontColor = System.Drawing.Color.White;
-            this.DefaultVisualSetting.FontOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
-            this.DefaultVisualSetting.Location = new System.Drawing.Point(293, 108);
-            this.DefaultVisualSetting.Name = "DefaultVisualSetting";
-            this.DefaultVisualSetting.Size = new System.Drawing.Size(306, 71);
-            this.DefaultVisualSetting.TabIndex = 37;
             // 
             // ConfigPanel
             // 
@@ -2705,5 +2729,7 @@
         private System.Windows.Forms.Label label60;
         private System.Windows.Forms.NumericUpDown SpellIconSizeUpDown;
         private System.Windows.Forms.Label label61;
+        private System.Windows.Forms.CheckBox OverlapRecastTimeCheckBox;
+        private System.Windows.Forms.CheckBox HideSpellNameCheckBox;
     }
 }

--- a/ACT.SpecialSpellTimer/ConfigPanel.Designer.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.Designer.cs
@@ -61,7 +61,6 @@
             this.ExpandSecounds1NumericUpDown = new System.Windows.Forms.NumericUpDown();
             this.KeywordToExpand1TextBox = new System.Windows.Forms.TextBox();
             this.label50 = new System.Windows.Forms.Label();
-            this.SpellVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
             this.RegexEnabledCheckBox = new System.Windows.Forms.CheckBox();
             this.DontHideCheckBox = new System.Windows.Forms.CheckBox();
             this.label27 = new System.Windows.Forms.Label();
@@ -122,7 +121,6 @@
             this.OnPointTelopTabPage = new System.Windows.Forms.TabPage();
             this.TelopDetailGroupBox = new System.Windows.Forms.GroupBox();
             this.TelopSelectZoneButton = new System.Windows.Forms.Button();
-            this.TelopVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
             this.TelopSelectJobButton = new System.Windows.Forms.Button();
             this.TelopProgressBarEnabledCheckBox = new System.Windows.Forms.CheckBox();
             this.EnabledAddMessageCheckBox = new System.Windows.Forms.CheckBox();
@@ -225,12 +223,14 @@
             this.label18 = new System.Windows.Forms.Label();
             this.SwitchOverlayButton = new System.Windows.Forms.Button();
             this.ShokikaButton = new System.Windows.Forms.Button();
-            this.DefaultVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
             this.OpenFileDialog = new System.Windows.Forms.OpenFileDialog();
             this.SaveFileDialog = new System.Windows.Forms.SaveFileDialog();
             this.ToolTip = new System.Windows.Forms.ToolTip(this.components);
             this.CombatAnalyzingTimer = new System.Windows.Forms.Timer(this.components);
             this.EnabledSpellTimerNoDecimal = new System.Windows.Forms.CheckBox();
+            this.SpellVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
+            this.TelopVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
+            this.DefaultVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
             this.TabControl.SuspendLayout();
             this.SpecialSpellTabPage.SuspendLayout();
             this.DetailPanelGroupBox.SuspendLayout();
@@ -687,20 +687,6 @@
             this.label50.Size = new System.Drawing.Size(171, 12);
             this.label50.TabIndex = 52;
             this.label50.Text = "MatchingLogWordToExpandLabel";
-            // 
-            // SpellVisualSetting
-            // 
-            this.SpellVisualSetting.BackgroundColor = System.Drawing.Color.Empty;
-            this.SpellVisualSetting.BarColor = System.Drawing.Color.White;
-            this.SpellVisualSetting.BarEnabled = true;
-            this.SpellVisualSetting.BarOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
-            this.SpellVisualSetting.BarSize = new System.Drawing.Size(190, 8);
-            this.SpellVisualSetting.FontColor = System.Drawing.Color.White;
-            this.SpellVisualSetting.FontOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
-            this.SpellVisualSetting.Location = new System.Drawing.Point(195, 262);
-            this.SpellVisualSetting.Name = "SpellVisualSetting";
-            this.SpellVisualSetting.Size = new System.Drawing.Size(306, 71);
-            this.SpellVisualSetting.TabIndex = 51;
             // 
             // RegexEnabledCheckBox
             // 
@@ -1360,20 +1346,6 @@
             this.TelopSelectZoneButton.TabIndex = 46;
             this.TelopSelectZoneButton.Text = "SelectZoneButton";
             this.TelopSelectZoneButton.UseVisualStyleBackColor = true;
-            // 
-            // TelopVisualSetting
-            // 
-            this.TelopVisualSetting.BackgroundColor = System.Drawing.Color.Empty;
-            this.TelopVisualSetting.BarColor = System.Drawing.Color.White;
-            this.TelopVisualSetting.BarEnabled = false;
-            this.TelopVisualSetting.BarOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
-            this.TelopVisualSetting.BarSize = new System.Drawing.Size(190, 8);
-            this.TelopVisualSetting.FontColor = System.Drawing.Color.White;
-            this.TelopVisualSetting.FontOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
-            this.TelopVisualSetting.Location = new System.Drawing.Point(187, 143);
-            this.TelopVisualSetting.Name = "TelopVisualSetting";
-            this.TelopVisualSetting.Size = new System.Drawing.Size(306, 71);
-            this.TelopVisualSetting.TabIndex = 6;
             // 
             // TelopSelectJobButton
             // 
@@ -2423,20 +2395,6 @@
             this.ShokikaButton.UseVisualStyleBackColor = true;
             this.ShokikaButton.Click += new System.EventHandler(this.ShokikaButton_Click);
             // 
-            // DefaultVisualSetting
-            // 
-            this.DefaultVisualSetting.BackgroundColor = System.Drawing.Color.Empty;
-            this.DefaultVisualSetting.BarColor = System.Drawing.Color.White;
-            this.DefaultVisualSetting.BarEnabled = true;
-            this.DefaultVisualSetting.BarOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
-            this.DefaultVisualSetting.BarSize = new System.Drawing.Size(190, 8);
-            this.DefaultVisualSetting.FontColor = System.Drawing.Color.White;
-            this.DefaultVisualSetting.FontOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
-            this.DefaultVisualSetting.Location = new System.Drawing.Point(293, 108);
-            this.DefaultVisualSetting.Name = "DefaultVisualSetting";
-            this.DefaultVisualSetting.Size = new System.Drawing.Size(306, 71);
-            this.DefaultVisualSetting.TabIndex = 37;
-            // 
             // OpenFileDialog
             // 
             this.OpenFileDialog.DefaultExt = "xml";
@@ -2468,6 +2426,60 @@
             this.EnabledSpellTimerNoDecimal.TabIndex = 42;
             this.EnabledSpellTimerNoDecimal.Text = "Enabled";
             this.EnabledSpellTimerNoDecimal.UseVisualStyleBackColor = true;
+            // 
+            // SpellVisualSetting
+            // 
+            this.SpellVisualSetting.BackgroundColor = System.Drawing.Color.Empty;
+            this.SpellVisualSetting.BarColor = System.Drawing.Color.White;
+            this.SpellVisualSetting.BarEnabled = true;
+            this.SpellVisualSetting.BarOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
+            this.SpellVisualSetting.BarSize = new System.Drawing.Size(190, 8);
+            this.SpellVisualSetting.FontColor = System.Drawing.Color.White;
+            this.SpellVisualSetting.FontOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
+            this.SpellVisualSetting.HideSpellName = false;
+            this.SpellVisualSetting.Location = new System.Drawing.Point(195, 262);
+            this.SpellVisualSetting.Name = "SpellVisualSetting";
+            this.SpellVisualSetting.OverlapRecastTime = false;
+            this.SpellVisualSetting.Size = new System.Drawing.Size(306, 109);
+            this.SpellVisualSetting.SpellIcon = "";
+            this.SpellVisualSetting.SpellIconSize = 0;
+            this.SpellVisualSetting.TabIndex = 51;
+            // 
+            // TelopVisualSetting
+            // 
+            this.TelopVisualSetting.BackgroundColor = System.Drawing.Color.Empty;
+            this.TelopVisualSetting.BarColor = System.Drawing.Color.White;
+            this.TelopVisualSetting.BarEnabled = false;
+            this.TelopVisualSetting.BarOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
+            this.TelopVisualSetting.BarSize = new System.Drawing.Size(190, 8);
+            this.TelopVisualSetting.FontColor = System.Drawing.Color.White;
+            this.TelopVisualSetting.FontOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
+            this.TelopVisualSetting.HideSpellName = false;
+            this.TelopVisualSetting.Location = new System.Drawing.Point(187, 143);
+            this.TelopVisualSetting.Name = "TelopVisualSetting";
+            this.TelopVisualSetting.OverlapRecastTime = false;
+            this.TelopVisualSetting.Size = new System.Drawing.Size(306, 71);
+            this.TelopVisualSetting.SpellIcon = "";
+            this.TelopVisualSetting.SpellIconSize = 0;
+            this.TelopVisualSetting.TabIndex = 6;
+            // 
+            // DefaultVisualSetting
+            // 
+            this.DefaultVisualSetting.BackgroundColor = System.Drawing.Color.Empty;
+            this.DefaultVisualSetting.BarColor = System.Drawing.Color.White;
+            this.DefaultVisualSetting.BarEnabled = true;
+            this.DefaultVisualSetting.BarOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
+            this.DefaultVisualSetting.BarSize = new System.Drawing.Size(190, 8);
+            this.DefaultVisualSetting.FontColor = System.Drawing.Color.White;
+            this.DefaultVisualSetting.FontOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
+            this.DefaultVisualSetting.HideSpellName = false;
+            this.DefaultVisualSetting.Location = new System.Drawing.Point(293, 108);
+            this.DefaultVisualSetting.Name = "DefaultVisualSetting";
+            this.DefaultVisualSetting.OverlapRecastTime = false;
+            this.DefaultVisualSetting.Size = new System.Drawing.Size(306, 71);
+            this.DefaultVisualSetting.SpellIcon = "";
+            this.DefaultVisualSetting.SpellIconSize = 0;
+            this.DefaultVisualSetting.TabIndex = 37;
             // 
             // ConfigPanel
             // 

--- a/ACT.SpecialSpellTimer/ConfigPanel.Designer.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.Designer.cs
@@ -42,6 +42,10 @@
             this.DetailGroupBox = new System.Windows.Forms.GroupBox();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.SpellIconSizeUpDown = new System.Windows.Forms.NumericUpDown();
+            this.label61 = new System.Windows.Forms.Label();
+            this.SpellIconComboBox = new System.Windows.Forms.ComboBox();
+            this.label60 = new System.Windows.Forms.Label();
             this.label59 = new System.Windows.Forms.Label();
             this.UpperLimitOfExtensionNumericUpDown = new System.Windows.Forms.NumericUpDown();
             this.label58 = new System.Windows.Forms.Label();
@@ -55,7 +59,6 @@
             this.ExpandSecounds1NumericUpDown = new System.Windows.Forms.NumericUpDown();
             this.KeywordToExpand1TextBox = new System.Windows.Forms.TextBox();
             this.label50 = new System.Windows.Forms.Label();
-            this.SpellVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
             this.RegexEnabledCheckBox = new System.Windows.Forms.CheckBox();
             this.DontHideCheckBox = new System.Windows.Forms.CheckBox();
             this.label27 = new System.Windows.Forms.Label();
@@ -116,7 +119,6 @@
             this.OnPointTelopTabPage = new System.Windows.Forms.TabPage();
             this.TelopDetailGroupBox = new System.Windows.Forms.GroupBox();
             this.TelopSelectZoneButton = new System.Windows.Forms.Button();
-            this.TelopVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
             this.TelopSelectJobButton = new System.Windows.Forms.Button();
             this.TelopProgressBarEnabledCheckBox = new System.Windows.Forms.CheckBox();
             this.EnabledAddMessageCheckBox = new System.Windows.Forms.CheckBox();
@@ -162,6 +164,7 @@
             this.TelopExportButton = new System.Windows.Forms.Button();
             this.TelopTreeView = new System.Windows.Forms.TreeView();
             this.CombatAnalyzerTabPage = new System.Windows.Forms.TabPage();
+            this.ExportCSVButton = new System.Windows.Forms.Button();
             this.CombatLogListView = new System.Windows.Forms.ListView();
             this.DummyColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.NoColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
@@ -218,13 +221,14 @@
             this.label18 = new System.Windows.Forms.Label();
             this.SwitchOverlayButton = new System.Windows.Forms.Button();
             this.ShokikaButton = new System.Windows.Forms.Button();
-            this.DefaultVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
             this.OpenFileDialog = new System.Windows.Forms.OpenFileDialog();
             this.SaveFileDialog = new System.Windows.Forms.SaveFileDialog();
             this.ToolTip = new System.Windows.Forms.ToolTip(this.components);
             this.CombatAnalyzingTimer = new System.Windows.Forms.Timer(this.components);
             this.EnabledSpellTimerNoDecimal = new System.Windows.Forms.CheckBox();
-            this.ExportCSVButton = new System.Windows.Forms.Button();
+            this.SpellVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
+            this.TelopVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
+            this.DefaultVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
             this.TabControl.SuspendLayout();
             this.SpecialSpellTabPage.SuspendLayout();
             this.DetailPanelGroupBox.SuspendLayout();
@@ -233,6 +237,7 @@
             this.DetailGroupBox.SuspendLayout();
             this.tabControl1.SuspendLayout();
             this.tabPage1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.SpellIconSizeUpDown)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.UpperLimitOfExtensionNumericUpDown)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.ExpandSecounds2NumericUpDown)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.ExpandSecounds1NumericUpDown)).BeginInit();
@@ -425,6 +430,10 @@
             // 
             // tabPage1
             // 
+            this.tabPage1.Controls.Add(this.SpellIconSizeUpDown);
+            this.tabPage1.Controls.Add(this.label61);
+            this.tabPage1.Controls.Add(this.SpellIconComboBox);
+            this.tabPage1.Controls.Add(this.label60);
             this.tabPage1.Controls.Add(this.label59);
             this.tabPage1.Controls.Add(this.UpperLimitOfExtensionNumericUpDown);
             this.tabPage1.Controls.Add(this.label58);
@@ -463,10 +472,52 @@
             this.tabPage1.Text = "GeneralTab";
             this.tabPage1.UseVisualStyleBackColor = true;
             // 
+            // SpellIconSizeUpDown
+            // 
+            this.SpellIconSizeUpDown.ImeMode = System.Windows.Forms.ImeMode.Disable;
+            this.SpellIconSizeUpDown.Location = new System.Drawing.Point(574, 60);
+            this.SpellIconSizeUpDown.Maximum = new decimal(new int[] {
+            65535,
+            0,
+            0,
+            0});
+            this.SpellIconSizeUpDown.Name = "SpellIconSizeUpDown";
+            this.SpellIconSizeUpDown.Size = new System.Drawing.Size(68, 19);
+            this.SpellIconSizeUpDown.TabIndex = 68;
+            this.SpellIconSizeUpDown.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            // 
+            // label61
+            // 
+            this.label61.AutoSize = true;
+            this.label61.Location = new System.Drawing.Point(460, 62);
+            this.label61.Name = "label61";
+            this.label61.Size = new System.Drawing.Size(99, 12);
+            this.label61.TabIndex = 67;
+            this.label61.Text = "SpellIconSizeLabel";
+            // 
+            // SpellIconComboBox
+            // 
+            this.SpellIconComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.SpellIconComboBox.FormattingEnabled = true;
+            this.SpellIconComboBox.Location = new System.Drawing.Point(195, 59);
+            this.SpellIconComboBox.MaxDropDownItems = 16;
+            this.SpellIconComboBox.Name = "SpellIconComboBox";
+            this.SpellIconComboBox.Size = new System.Drawing.Size(243, 20);
+            this.SpellIconComboBox.TabIndex = 66;
+            // 
+            // label60
+            // 
+            this.label60.AutoSize = true;
+            this.label60.Location = new System.Drawing.Point(6, 62);
+            this.label60.Name = "label60";
+            this.label60.Size = new System.Drawing.Size(78, 12);
+            this.label60.TabIndex = 65;
+            this.label60.Text = "SpellIconLabel";
+            // 
             // label59
             // 
             this.label59.AutoSize = true;
-            this.label59.Location = new System.Drawing.Point(273, 195);
+            this.label59.Location = new System.Drawing.Point(273, 218);
             this.label59.Name = "label59";
             this.label59.Size = new System.Drawing.Size(92, 12);
             this.label59.TabIndex = 64;
@@ -475,7 +526,7 @@
             // UpperLimitOfExtensionNumericUpDown
             // 
             this.UpperLimitOfExtensionNumericUpDown.ImeMode = System.Windows.Forms.ImeMode.Disable;
-            this.UpperLimitOfExtensionNumericUpDown.Location = new System.Drawing.Point(195, 193);
+            this.UpperLimitOfExtensionNumericUpDown.Location = new System.Drawing.Point(195, 216);
             this.UpperLimitOfExtensionNumericUpDown.Margin = new System.Windows.Forms.Padding(6);
             this.UpperLimitOfExtensionNumericUpDown.Maximum = new decimal(new int[] {
             65535,
@@ -490,7 +541,7 @@
             // label58
             // 
             this.label58.AutoSize = true;
-            this.label58.Location = new System.Drawing.Point(178, 145);
+            this.label58.Location = new System.Drawing.Point(178, 168);
             this.label58.Name = "label58";
             this.label58.Size = new System.Drawing.Size(52, 12);
             this.label58.TabIndex = 62;
@@ -499,7 +550,7 @@
             // label57
             // 
             this.label57.AutoSize = true;
-            this.label57.Location = new System.Drawing.Point(6, 145);
+            this.label57.Location = new System.Drawing.Point(6, 168);
             this.label57.Name = "label57";
             this.label57.Size = new System.Drawing.Size(171, 12);
             this.label57.TabIndex = 61;
@@ -508,7 +559,7 @@
             // label56
             // 
             this.label56.AutoSize = true;
-            this.label56.Location = new System.Drawing.Point(178, 120);
+            this.label56.Location = new System.Drawing.Point(178, 143);
             this.label56.Name = "label56";
             this.label56.Size = new System.Drawing.Size(52, 12);
             this.label56.TabIndex = 60;
@@ -518,7 +569,7 @@
             // 
             this.label55.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label55.AutoSize = true;
-            this.label55.Location = new System.Drawing.Point(707, 144);
+            this.label55.Location = new System.Drawing.Point(707, 167);
             this.label55.Name = "label55";
             this.label55.Size = new System.Drawing.Size(75, 12);
             this.label55.TabIndex = 59;
@@ -528,7 +579,7 @@
             // 
             this.ExpandSecounds2NumericUpDown.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.ExpandSecounds2NumericUpDown.ImeMode = System.Windows.Forms.ImeMode.Disable;
-            this.ExpandSecounds2NumericUpDown.Location = new System.Drawing.Point(630, 142);
+            this.ExpandSecounds2NumericUpDown.Location = new System.Drawing.Point(630, 165);
             this.ExpandSecounds2NumericUpDown.Margin = new System.Windows.Forms.Padding(6);
             this.ExpandSecounds2NumericUpDown.Maximum = new decimal(new int[] {
             65535,
@@ -549,7 +600,7 @@
             // 
             this.KeywordToExpand2TextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.KeywordToExpand2TextBox.Location = new System.Drawing.Point(195, 142);
+            this.KeywordToExpand2TextBox.Location = new System.Drawing.Point(195, 165);
             this.KeywordToExpand2TextBox.Name = "KeywordToExpand2TextBox";
             this.KeywordToExpand2TextBox.Size = new System.Drawing.Size(426, 19);
             this.KeywordToExpand2TextBox.TabIndex = 57;
@@ -557,7 +608,7 @@
             // ExtendBeyondOriginalRecastTimeCheckBox
             // 
             this.ExtendBeyondOriginalRecastTimeCheckBox.AutoSize = true;
-            this.ExtendBeyondOriginalRecastTimeCheckBox.Location = new System.Drawing.Point(195, 168);
+            this.ExtendBeyondOriginalRecastTimeCheckBox.Location = new System.Drawing.Point(195, 191);
             this.ExtendBeyondOriginalRecastTimeCheckBox.Name = "ExtendBeyondOriginalRecastTimeCheckBox";
             this.ExtendBeyondOriginalRecastTimeCheckBox.Size = new System.Drawing.Size(249, 16);
             this.ExtendBeyondOriginalRecastTimeCheckBox.TabIndex = 56;
@@ -568,7 +619,7 @@
             // 
             this.label51.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label51.AutoSize = true;
-            this.label51.Location = new System.Drawing.Point(707, 120);
+            this.label51.Location = new System.Drawing.Point(707, 143);
             this.label51.Name = "label51";
             this.label51.Size = new System.Drawing.Size(75, 12);
             this.label51.TabIndex = 55;
@@ -578,7 +629,7 @@
             // 
             this.ExpandSecounds1NumericUpDown.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.ExpandSecounds1NumericUpDown.ImeMode = System.Windows.Forms.ImeMode.Disable;
-            this.ExpandSecounds1NumericUpDown.Location = new System.Drawing.Point(630, 118);
+            this.ExpandSecounds1NumericUpDown.Location = new System.Drawing.Point(630, 141);
             this.ExpandSecounds1NumericUpDown.Margin = new System.Windows.Forms.Padding(6);
             this.ExpandSecounds1NumericUpDown.Maximum = new decimal(new int[] {
             65535,
@@ -599,7 +650,7 @@
             // 
             this.KeywordToExpand1TextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.KeywordToExpand1TextBox.Location = new System.Drawing.Point(195, 117);
+            this.KeywordToExpand1TextBox.Location = new System.Drawing.Point(195, 140);
             this.KeywordToExpand1TextBox.Name = "KeywordToExpand1TextBox";
             this.KeywordToExpand1TextBox.Size = new System.Drawing.Size(426, 19);
             this.KeywordToExpand1TextBox.TabIndex = 53;
@@ -607,31 +658,17 @@
             // label50
             // 
             this.label50.AutoSize = true;
-            this.label50.Location = new System.Drawing.Point(6, 120);
+            this.label50.Location = new System.Drawing.Point(6, 143);
             this.label50.Name = "label50";
             this.label50.Size = new System.Drawing.Size(171, 12);
             this.label50.TabIndex = 52;
             this.label50.Text = "MatchingLogWordToExpandLabel";
             // 
-            // SpellVisualSetting
-            // 
-            this.SpellVisualSetting.BackgroundColor = System.Drawing.Color.Empty;
-            this.SpellVisualSetting.BarColor = System.Drawing.Color.White;
-            this.SpellVisualSetting.BarEnabled = true;
-            this.SpellVisualSetting.BarOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
-            this.SpellVisualSetting.BarSize = new System.Drawing.Size(190, 8);
-            this.SpellVisualSetting.FontColor = System.Drawing.Color.White;
-            this.SpellVisualSetting.FontOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
-            this.SpellVisualSetting.Location = new System.Drawing.Point(195, 239);
-            this.SpellVisualSetting.Name = "SpellVisualSetting";
-            this.SpellVisualSetting.Size = new System.Drawing.Size(306, 71);
-            this.SpellVisualSetting.TabIndex = 51;
-            // 
             // RegexEnabledCheckBox
             // 
             this.RegexEnabledCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.RegexEnabledCheckBox.AutoSize = true;
-            this.RegexEnabledCheckBox.Location = new System.Drawing.Point(704, 63);
+            this.RegexEnabledCheckBox.Location = new System.Drawing.Point(704, 86);
             this.RegexEnabledCheckBox.Name = "RegexEnabledCheckBox";
             this.RegexEnabledCheckBox.Size = new System.Drawing.Size(76, 16);
             this.RegexEnabledCheckBox.TabIndex = 41;
@@ -641,7 +678,7 @@
             // DontHideCheckBox
             // 
             this.DontHideCheckBox.AutoSize = true;
-            this.DontHideCheckBox.Location = new System.Drawing.Point(519, 288);
+            this.DontHideCheckBox.Location = new System.Drawing.Point(519, 311);
             this.DontHideCheckBox.Name = "DontHideCheckBox";
             this.DontHideCheckBox.Size = new System.Drawing.Size(123, 16);
             this.DontHideCheckBox.TabIndex = 48;
@@ -683,7 +720,7 @@
             // IsReverseCheckBox
             // 
             this.IsReverseCheckBox.AutoSize = true;
-            this.IsReverseCheckBox.Location = new System.Drawing.Point(519, 266);
+            this.IsReverseCheckBox.Location = new System.Drawing.Point(519, 289);
             this.IsReverseCheckBox.Name = "IsReverseCheckBox";
             this.IsReverseCheckBox.Size = new System.Drawing.Size(162, 16);
             this.IsReverseCheckBox.TabIndex = 47;
@@ -693,7 +730,7 @@
             // ShowProgressBarCheckBox
             // 
             this.ShowProgressBarCheckBox.AutoSize = true;
-            this.ShowProgressBarCheckBox.Location = new System.Drawing.Point(519, 244);
+            this.ShowProgressBarCheckBox.Location = new System.Drawing.Point(519, 267);
             this.ShowProgressBarCheckBox.Name = "ShowProgressBarCheckBox";
             this.ShowProgressBarCheckBox.Size = new System.Drawing.Size(166, 16);
             this.ShowProgressBarCheckBox.TabIndex = 46;
@@ -703,7 +740,7 @@
             // RepeatCheckBox
             // 
             this.RepeatCheckBox.AutoSize = true;
-            this.RepeatCheckBox.Location = new System.Drawing.Point(269, 90);
+            this.RepeatCheckBox.Location = new System.Drawing.Point(269, 113);
             this.RepeatCheckBox.Name = "RepeatCheckBox";
             this.RepeatCheckBox.Size = new System.Drawing.Size(112, 16);
             this.RepeatCheckBox.TabIndex = 44;
@@ -713,7 +750,7 @@
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(6, 91);
+            this.label4.Location = new System.Drawing.Point(6, 114);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(93, 12);
             this.label4.TabIndex = 45;
@@ -722,7 +759,7 @@
             // RecastTimeNumericUpDown
             // 
             this.RecastTimeNumericUpDown.ImeMode = System.Windows.Forms.ImeMode.Disable;
-            this.RecastTimeNumericUpDown.Location = new System.Drawing.Point(195, 89);
+            this.RecastTimeNumericUpDown.Location = new System.Drawing.Point(195, 112);
             this.RecastTimeNumericUpDown.Margin = new System.Windows.Forms.Padding(6);
             this.RecastTimeNumericUpDown.Maximum = new decimal(new int[] {
             65535,
@@ -737,7 +774,7 @@
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(6, 64);
+            this.label3.Location = new System.Drawing.Point(6, 87);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(121, 12);
             this.label3.TabIndex = 42;
@@ -747,7 +784,7 @@
             // 
             this.KeywordTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.KeywordTextBox.Location = new System.Drawing.Point(195, 61);
+            this.KeywordTextBox.Location = new System.Drawing.Point(195, 84);
             this.KeywordTextBox.Name = "KeywordTextBox";
             this.KeywordTextBox.Size = new System.Drawing.Size(503, 19);
             this.KeywordTextBox.TabIndex = 40;
@@ -1286,20 +1323,6 @@
             this.TelopSelectZoneButton.Text = "SelectZoneButton";
             this.TelopSelectZoneButton.UseVisualStyleBackColor = true;
             // 
-            // TelopVisualSetting
-            // 
-            this.TelopVisualSetting.BackgroundColor = System.Drawing.Color.Empty;
-            this.TelopVisualSetting.BarColor = System.Drawing.Color.White;
-            this.TelopVisualSetting.BarEnabled = false;
-            this.TelopVisualSetting.BarOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
-            this.TelopVisualSetting.BarSize = new System.Drawing.Size(190, 8);
-            this.TelopVisualSetting.FontColor = System.Drawing.Color.White;
-            this.TelopVisualSetting.FontOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
-            this.TelopVisualSetting.Location = new System.Drawing.Point(187, 143);
-            this.TelopVisualSetting.Name = "TelopVisualSetting";
-            this.TelopVisualSetting.Size = new System.Drawing.Size(306, 71);
-            this.TelopVisualSetting.TabIndex = 6;
-            // 
             // TelopSelectJobButton
             // 
             this.TelopSelectJobButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
@@ -1776,6 +1799,17 @@
             this.CombatAnalyzerTabPage.TabIndex = 3;
             this.CombatAnalyzerTabPage.Text = "CombatAnalyzerTabTitle";
             // 
+            // ExportCSVButton
+            // 
+            this.ExportCSVButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.ExportCSVButton.Location = new System.Drawing.Point(1078, 637);
+            this.ExportCSVButton.Name = "ExportCSVButton";
+            this.ExportCSVButton.Size = new System.Drawing.Size(95, 25);
+            this.ExportCSVButton.TabIndex = 20;
+            this.ExportCSVButton.Text = "ExportCSVButton";
+            this.ExportCSVButton.UseVisualStyleBackColor = true;
+            this.ExportCSVButton.Click += new System.EventHandler(this.ExportCSVButton_Click);
+            // 
             // CombatLogListView
             // 
             this.CombatLogListView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
@@ -1870,26 +1904,26 @@
             this.toolStripSeparator2,
             this.CASetOriginItem});
             this.CombatAnalyzerContextMenuStrip.Name = "CombatAnalyzerContextMenuStrip";
-            this.CombatAnalyzerContextMenuStrip.Size = new System.Drawing.Size(264, 104);
+            this.CombatAnalyzerContextMenuStrip.Size = new System.Drawing.Size(242, 104);
             // 
             // CASelectAllItem
             // 
             this.CASelectAllItem.Name = "CASelectAllItem";
             this.CASelectAllItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.A)));
-            this.CASelectAllItem.Size = new System.Drawing.Size(263, 22);
+            this.CASelectAllItem.Size = new System.Drawing.Size(241, 22);
             this.CASelectAllItem.Text = "SelectAll";
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(260, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(238, 6);
             // 
             // CACopyLogItem
             // 
             this.CACopyLogItem.Name = "CACopyLogItem";
             this.CACopyLogItem.ShortcutKeyDisplayString = "";
             this.CACopyLogItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-            this.CACopyLogItem.Size = new System.Drawing.Size(263, 22);
+            this.CACopyLogItem.Size = new System.Drawing.Size(241, 22);
             this.CACopyLogItem.Text = "CopyLog";
             // 
             // CACopyLogDetailItem
@@ -1897,19 +1931,19 @@
             this.CACopyLogDetailItem.Name = "CACopyLogDetailItem";
             this.CACopyLogDetailItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.C)));
-            this.CACopyLogDetailItem.Size = new System.Drawing.Size(263, 22);
+            this.CACopyLogDetailItem.Size = new System.Drawing.Size(241, 22);
             this.CACopyLogDetailItem.Text = "CopyLogDetail";
             // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(260, 6);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(238, 6);
             // 
             // CASetOriginItem
             // 
             this.CASetOriginItem.Name = "CASetOriginItem";
             this.CASetOriginItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-            this.CASetOriginItem.Size = new System.Drawing.Size(263, 22);
+            this.CASetOriginItem.Size = new System.Drawing.Size(241, 22);
             this.CASetOriginItem.Text = "SetLogOrigin";
             // 
             // label6
@@ -2337,20 +2371,6 @@
             this.ShokikaButton.UseVisualStyleBackColor = true;
             this.ShokikaButton.Click += new System.EventHandler(this.ShokikaButton_Click);
             // 
-            // DefaultVisualSetting
-            // 
-            this.DefaultVisualSetting.BackgroundColor = System.Drawing.Color.Empty;
-            this.DefaultVisualSetting.BarColor = System.Drawing.Color.White;
-            this.DefaultVisualSetting.BarEnabled = true;
-            this.DefaultVisualSetting.BarOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
-            this.DefaultVisualSetting.BarSize = new System.Drawing.Size(190, 8);
-            this.DefaultVisualSetting.FontColor = System.Drawing.Color.White;
-            this.DefaultVisualSetting.FontOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
-            this.DefaultVisualSetting.Location = new System.Drawing.Point(293, 108);
-            this.DefaultVisualSetting.Name = "DefaultVisualSetting";
-            this.DefaultVisualSetting.Size = new System.Drawing.Size(306, 71);
-            this.DefaultVisualSetting.TabIndex = 37;
-            // 
             // OpenFileDialog
             // 
             this.OpenFileDialog.DefaultExt = "xml";
@@ -2383,16 +2403,47 @@
             this.EnabledSpellTimerNoDecimal.Text = "Enabled";
             this.EnabledSpellTimerNoDecimal.UseVisualStyleBackColor = true;
             // 
-            // ExportCSVButton
+            // SpellVisualSetting
             // 
-            this.ExportCSVButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.ExportCSVButton.Location = new System.Drawing.Point(1078, 637);
-            this.ExportCSVButton.Name = "ExportCSVButton";
-            this.ExportCSVButton.Size = new System.Drawing.Size(95, 25);
-            this.ExportCSVButton.TabIndex = 20;
-            this.ExportCSVButton.Text = "ExportCSVButton";
-            this.ExportCSVButton.UseVisualStyleBackColor = true;
-            this.ExportCSVButton.Click += new System.EventHandler(this.ExportCSVButton_Click);
+            this.SpellVisualSetting.BackgroundColor = System.Drawing.Color.Empty;
+            this.SpellVisualSetting.BarColor = System.Drawing.Color.White;
+            this.SpellVisualSetting.BarEnabled = true;
+            this.SpellVisualSetting.BarOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
+            this.SpellVisualSetting.BarSize = new System.Drawing.Size(190, 8);
+            this.SpellVisualSetting.FontColor = System.Drawing.Color.White;
+            this.SpellVisualSetting.FontOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
+            this.SpellVisualSetting.Location = new System.Drawing.Point(195, 262);
+            this.SpellVisualSetting.Name = "SpellVisualSetting";
+            this.SpellVisualSetting.Size = new System.Drawing.Size(306, 71);
+            this.SpellVisualSetting.TabIndex = 51;
+            // 
+            // TelopVisualSetting
+            // 
+            this.TelopVisualSetting.BackgroundColor = System.Drawing.Color.Empty;
+            this.TelopVisualSetting.BarColor = System.Drawing.Color.White;
+            this.TelopVisualSetting.BarEnabled = false;
+            this.TelopVisualSetting.BarOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
+            this.TelopVisualSetting.BarSize = new System.Drawing.Size(190, 8);
+            this.TelopVisualSetting.FontColor = System.Drawing.Color.White;
+            this.TelopVisualSetting.FontOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
+            this.TelopVisualSetting.Location = new System.Drawing.Point(187, 143);
+            this.TelopVisualSetting.Name = "TelopVisualSetting";
+            this.TelopVisualSetting.Size = new System.Drawing.Size(306, 71);
+            this.TelopVisualSetting.TabIndex = 6;
+            // 
+            // DefaultVisualSetting
+            // 
+            this.DefaultVisualSetting.BackgroundColor = System.Drawing.Color.Empty;
+            this.DefaultVisualSetting.BarColor = System.Drawing.Color.White;
+            this.DefaultVisualSetting.BarEnabled = true;
+            this.DefaultVisualSetting.BarOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
+            this.DefaultVisualSetting.BarSize = new System.Drawing.Size(190, 8);
+            this.DefaultVisualSetting.FontColor = System.Drawing.Color.White;
+            this.DefaultVisualSetting.FontOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
+            this.DefaultVisualSetting.Location = new System.Drawing.Point(293, 108);
+            this.DefaultVisualSetting.Name = "DefaultVisualSetting";
+            this.DefaultVisualSetting.Size = new System.Drawing.Size(306, 71);
+            this.DefaultVisualSetting.TabIndex = 37;
             // 
             // ConfigPanel
             // 
@@ -2411,6 +2462,7 @@
             this.tabControl1.ResumeLayout(false);
             this.tabPage1.ResumeLayout(false);
             this.tabPage1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.SpellIconSizeUpDown)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.UpperLimitOfExtensionNumericUpDown)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.ExpandSecounds2NumericUpDown)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.ExpandSecounds1NumericUpDown)).EndInit();
@@ -2649,5 +2701,9 @@
         private System.Windows.Forms.Label label59;
         private System.Windows.Forms.NumericUpDown UpperLimitOfExtensionNumericUpDown;
         internal System.Windows.Forms.Button ExportCSVButton;
+        private System.Windows.Forms.ComboBox SpellIconComboBox;
+        private System.Windows.Forms.Label label60;
+        private System.Windows.Forms.NumericUpDown SpellIconSizeUpDown;
+        private System.Windows.Forms.Label label61;
     }
 }

--- a/ACT.SpecialSpellTimer/ConfigPanel.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.cs
@@ -252,6 +252,8 @@
                         nr.BarColor = baseRow.BarColor;
                         nr.BarOutlineColor = baseRow.BarOutlineColor;
                         nr.DontHide = baseRow.DontHide;
+                        nr.HideSpellName = baseRow.HideSpellName;
+                        nr.OverlapRecastTime = baseRow.OverlapRecastTime;
                         nr.FontFamily = baseRow.FontFamily;
                         nr.FontSize = baseRow.FontSize;
                         nr.FontStyle = baseRow.FontStyle;
@@ -378,6 +380,8 @@
 
                     src.IsReverse = this.IsReverseCheckBox.Checked;
                     src.DontHide = this.DontHideCheckBox.Checked;
+                    src.HideSpellName = this.HideSpellNameCheckBox.Checked;
+                    src.OverlapRecastTime = this.OverlapRecastTimeCheckBox.Checked;
 
                     src.Font = this.SpellVisualSetting.GetFontInfo();
                     src.FontColor = this.SpellVisualSetting.FontColor.ToHTML();
@@ -631,6 +635,8 @@
 
             this.IsReverseCheckBox.Checked = src.IsReverse;
             this.DontHideCheckBox.Checked = src.DontHide;
+            this.HideSpellNameCheckBox.Checked = src.HideSpellName;
+            this.OverlapRecastTimeCheckBox.Checked = src.OverlapRecastTime;
 
             this.SpellVisualSetting.SetFontInfo(src.Font);
             this.SpellVisualSetting.BarColor = string.IsNullOrWhiteSpace(src.BarColor) ?

--- a/ACT.SpecialSpellTimer/ConfigPanel.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.cs
@@ -7,6 +7,7 @@
     using System.Reflection;
     using System.Windows.Forms;
 
+    using ACT.SpecialSpellTimer.Image;
     using ACT.SpecialSpellTimer.Properties;
     using ACT.SpecialSpellTimer.Sound;
     using ACT.SpecialSpellTimer.Utility;
@@ -75,6 +76,10 @@
             this.TimeupSoundComboBox.DataSource = SoundController.Default.EnumlateWave();
             this.TimeupSoundComboBox.ValueMember = "FullPath";
             this.TimeupSoundComboBox.DisplayMember = "Name";
+
+            this.SpellIconComboBox.DataSource = IconController.Default.EnumlateIcon();
+            this.SpellIconComboBox.ValueMember = "RelativePath";
+            this.SpellIconComboBox.DisplayMember = "RelativePath";
 
             // イベントを設定する
             this.SpellTimerTreeView.AfterSelect += this.SpellTimerTreeView_AfterSelect;
@@ -202,6 +207,7 @@
                     1;
                 nr.Panel = "General";
                 nr.SpellTitle = "New Spell";
+                nr.SpellIconSize = 24;
                 nr.ProgressBarVisible = true;
                 nr.FontColor = Settings.Default.FontColor.ToHTML();
                 nr.FontOutlineColor = Settings.Default.FontOutlineColor.ToHTML();
@@ -227,6 +233,8 @@
                     {
                         nr.Panel = baseRow.Panel;
                         nr.SpellTitle = baseRow.SpellTitle + " New";
+                        nr.SpellIcon = baseRow.SpellIcon;
+                        nr.SpellIconSize = baseRow.SpellIconSize;
                         nr.Keyword = baseRow.Keyword;
                         nr.RegexEnabled = baseRow.RegexEnabled;
                         nr.RecastTime = baseRow.RecastTime;
@@ -338,6 +346,8 @@
                 {
                     src.Panel = this.PanelNameTextBox.Text;
                     src.SpellTitle = this.SpellTitleTextBox.Text;
+                    src.SpellIcon = (string)this.SpellIconComboBox.SelectedValue ?? string.Empty;
+                    src.SpellIconSize = (int)this.SpellIconSizeUpDown.Value;
                     src.DisplayNo = (int)this.DisplayNoNumericUpDown.Value;
                     src.Keyword = this.KeywordTextBox.Text;
                     src.RegexEnabled = this.RegexEnabledCheckBox.Checked;
@@ -589,6 +599,8 @@
 
             this.PanelNameTextBox.Text = src.Panel;
             this.SpellTitleTextBox.Text = src.SpellTitle;
+            this.SpellIconComboBox.SelectedValue = src.SpellIcon;
+            this.SpellIconSizeUpDown.Value = src.SpellIconSize;
             this.DisplayNoNumericUpDown.Value = src.DisplayNo;
             this.KeywordTextBox.Text = src.Keyword;
             this.RegexEnabledCheckBox.Checked = src.RegexEnabled;

--- a/ACT.SpecialSpellTimer/ConfigPanel.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.cs
@@ -181,6 +181,30 @@
                 }
             };
 
+            this.SpellIconComboBox.SelectionChangeCommitted += (s1, e1) =>
+            {
+                this.SpellVisualSetting.SpellIcon = (string)this.SpellIconComboBox.SelectedValue;
+                this.SpellVisualSetting.RefreshSampleImage();
+            };
+
+            this.SpellIconSizeUpDown.ValueChanged += (s1, e1) =>
+            {
+                this.SpellVisualSetting.SpellIconSize = (int)this.SpellIconSizeUpDown.Value;
+                this.SpellVisualSetting.RefreshSampleImage();
+            };
+
+            this.HideSpellNameCheckBox.CheckedChanged += (s1, e1) =>
+            {
+                this.SpellVisualSetting.HideSpellName = this.HideSpellNameCheckBox.Checked;
+                this.SpellVisualSetting.RefreshSampleImage();
+            };
+
+            this.OverlapRecastTimeCheckBox.CheckedChanged += (s1, e1) =>
+            {
+                this.SpellVisualSetting.OverlapRecastTime = this.OverlapRecastTimeCheckBox.Checked;
+                this.SpellVisualSetting.RefreshSampleImage();
+            };
+
             // オプションのロードメソッドを呼ぶ
             this.LoadOption();
 
@@ -207,6 +231,7 @@
                     1;
                 nr.Panel = "General";
                 nr.SpellTitle = "New Spell";
+                nr.SpellIcon = string.Empty;
                 nr.SpellIconSize = 24;
                 nr.ProgressBarVisible = true;
                 nr.FontColor = Settings.Default.FontColor.ToHTML();
@@ -655,6 +680,11 @@
             this.SpellVisualSetting.BackgroundColor = string.IsNullOrWhiteSpace(src.BackgroundColor) ?
                 Settings.Default.BackgroundColor :
                 Color.FromArgb(src.BackgroundAlpha, src.BackgroundColor.FromHTML());
+
+            this.SpellVisualSetting.SpellIcon = src.SpellIcon;
+            this.SpellVisualSetting.SpellIconSize = src.SpellIconSize;
+            this.SpellVisualSetting.HideSpellName = src.HideSpellName;
+            this.SpellVisualSetting.OverlapRecastTime = src.OverlapRecastTime;
 
             this.SpellVisualSetting.RefreshSampleImage();
 

--- a/ACT.SpecialSpellTimer/Image/IconController.cs
+++ b/ACT.SpecialSpellTimer/Image/IconController.cs
@@ -1,0 +1,162 @@
+﻿namespace ACT.SpecialSpellTimer.Image
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+    using System.Threading.Tasks;
+    using System.Diagnostics;
+
+    using ACT.SpecialSpellTimer.Utility;
+    using Advanced_Combat_Tracker;
+
+    class IconController
+    {
+        /// <summary>
+        /// シングルトンinstance
+        /// </summary>
+        private static IconController instance;
+
+        /// <summary>
+        /// シングルトンinstance
+        /// </summary>
+        public static IconController Default
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    instance = new IconController();
+                }
+
+                return instance;
+            }
+        }
+
+        public string IconDirectory
+        {
+            get
+            {
+                // ACTのパスを取得する
+                var asm = Assembly.GetEntryAssembly();
+                if (asm != null)
+                {
+                    var actDirectory = Path.GetDirectoryName(asm.Location);
+                    var resourcesUnderAct = Path.Combine(actDirectory, @"resources\icon");
+
+                    if (Directory.Exists(resourcesUnderAct))
+                    {
+                        return resourcesUnderAct;
+                    }
+                }
+
+                // 自身の場所を取得する
+                var selfDirectory = SpecialSpellTimerPlugin.Location ?? string.Empty;
+                var resourcesUnderThis = Path.Combine(selfDirectory, @"resources\icon");
+
+                if (Directory.Exists(resourcesUnderThis))
+                {
+                    return resourcesUnderThis;
+                }
+
+                return string.Empty;
+            }
+        }
+
+        public IconFile getIconFile(String relativePath)
+        {
+            var iconPath = Path.Combine(this.IconDirectory, relativePath);
+            if (File.Exists(iconPath))
+            {
+                return new IconFile()
+                {
+                    FullPath = iconPath.ToString(),
+                    RelativePath = relativePath
+                };
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Iconファイルを列挙する
+        /// </summary>
+        /// <returns>
+        /// Iconファイルのコレクション</returns>
+        public IconFile[] EnumlateIcon()
+        {
+            var list = new List<IconFile>();
+
+            // 未選択用のダミーをセットしておく
+            list.Add(new IconFile()
+            {
+                FullPath = string.Empty
+            });
+
+            if (Directory.Exists(this.IconDirectory))
+            {
+                list.AddRange(EmulateIcon(this.IconDirectory, ""));
+            }
+            return list.ToArray();
+        }
+
+        private IconFile[] EmulateIcon(String target, String prefix)
+        {
+            var list = new List<IconFile>();
+
+            foreach (var dir in Directory.GetDirectories(target))
+            {
+                list.AddRange(EmulateIcon(dir, prefix + Path.GetFileName(dir) + Path.DirectorySeparatorChar));
+            }
+
+            foreach (var file in Directory.GetFiles(target, "*.png"))
+            {
+                list.Add(new IconFile()
+                {
+                    FullPath = file,
+                    RelativePath = prefix + Path.GetFileName(file)
+                });
+            }
+
+            return list.ToArray();
+        }
+
+        /// <summary>
+        /// Iconファイル
+        /// </summary>
+        public class IconFile
+        {
+            /// <summary>
+            /// フルパス
+            /// </summary>
+            public string FullPath { get; set; }
+
+            /// <summary>
+            /// フルパス
+            /// </summary>
+            public string RelativePath { get; set; }
+
+            /// <summary>
+            /// ファイル名
+            /// </summary>
+            public string Name
+            {
+                get
+                {
+                    return !string.IsNullOrWhiteSpace(this.FullPath) ?
+                        Path.GetFileName(this.FullPath) :
+                        string.Empty;
+                }
+            }
+
+            /// <summary>
+            /// ToString()
+            /// </summary>
+            /// <returns>一般化された文字列</returns>
+            public override string ToString()
+            {
+                return this.Name;
+            }
+        }
+    }
+}

--- a/ACT.SpecialSpellTimer/Image/IconController.cs
+++ b/ACT.SpecialSpellTimer/Image/IconController.cs
@@ -66,6 +66,11 @@
 
         public IconFile getIconFile(String relativePath)
         {
+            if (relativePath == string.Empty || relativePath == null)
+            {
+                return null;
+            }
+
             var iconPath = Path.Combine(this.IconDirectory, relativePath);
             if (File.Exists(iconPath))
             {
@@ -90,7 +95,8 @@
             // 未選択用のダミーをセットしておく
             list.Add(new IconFile()
             {
-                FullPath = string.Empty
+                FullPath = string.Empty,
+                RelativePath = string.Empty
             });
 
             if (Directory.Exists(this.IconDirectory))

--- a/ACT.SpecialSpellTimer/SpellTimerControl.xaml
+++ b/ACT.SpecialSpellTimer/SpellTimerControl.xaml
@@ -50,7 +50,7 @@
       <Image x:Name="SpellIconImage"></Image>
     </DockPanel>
 
-    <DockPanel Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left">
+    <DockPanel Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Bottom">
       <Utility:OutlineTextBlock 
         x:Name="SpellTitleTextBlock" 
         HorizontalAlignment="Left" 
@@ -71,7 +71,7 @@
       </Utility:OutlineTextBlock>
     </DockPanel>
 
-    <DockPanel x:Name="RecastTimePanel" Grid.Row="0" Grid.Column="2" HorizontalAlignment="Right">
+    <DockPanel x:Name="RecastTimePanel" Grid.Row="0" Grid.Column="2" HorizontalAlignment="Right" VerticalAlignment="Bottom">
       <Utility:OutlineTextBlock
         x:Name="RecastTimeTextBlock" 
         HorizontalAlignment="Right" 

--- a/ACT.SpecialSpellTimer/SpellTimerControl.xaml
+++ b/ACT.SpecialSpellTimer/SpellTimerControl.xaml
@@ -40,6 +40,7 @@
     </Canvas>
 
     <DockPanel Grid.Row="0">
+      <Image x:Name="SpellIconImage"></Image>
       <Utility:OutlineTextBlock 
         x:Name="SpellTitleTextBlock" 
         HorizontalAlignment="Left" 

--- a/ACT.SpecialSpellTimer/SpellTimerControl.xaml
+++ b/ACT.SpecialSpellTimer/SpellTimerControl.xaml
@@ -18,9 +18,16 @@
       <RowDefinition/>
       <RowDefinition/>
     </Grid.RowDefinitions>
+    <Grid.ColumnDefinitions>
+      <ColumnDefinition Width="Auto"/>
+      <ColumnDefinition Width="Auto"/>
+      <ColumnDefinition/>
+    </Grid.ColumnDefinitions>
 
     <Canvas 
       Grid.Row="1"
+      Grid.Column="0"
+      Grid.ColumnSpan="3"
       Name="ProgressBarCanvas"
       Margin="0,2,0,10"
       VerticalAlignment="Top" 
@@ -39,8 +46,11 @@
       <Rectangle x:Name="BarOutlineRectangle" />
     </Canvas>
 
-    <DockPanel Grid.Row="0">
+    <DockPanel Grid.Row="0" Grid.Column="0" Panel.ZIndex="-1">
       <Image x:Name="SpellIconImage"></Image>
+    </DockPanel>
+
+    <DockPanel Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left">
       <Utility:OutlineTextBlock 
         x:Name="SpellTitleTextBlock" 
         HorizontalAlignment="Left" 
@@ -59,8 +69,10 @@
             Color="{Binding ElementName=RecastTimeTextBlock, Path=Stroke.Color, Mode=OneWay}" />
         </Utility:OutlineTextBlock.Effect>
       </Utility:OutlineTextBlock>
+    </DockPanel>
 
-      <Utility:OutlineTextBlock 
+    <DockPanel x:Name="RecastTimePanel" Grid.Row="0" Grid.Column="2" HorizontalAlignment="Right">
+      <Utility:OutlineTextBlock
         x:Name="RecastTimeTextBlock" 
         HorizontalAlignment="Right" 
         VerticalAlignment="Top"

--- a/ACT.SpecialSpellTimer/SpellTimerControl.xaml.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerControl.xaml.cs
@@ -62,6 +62,16 @@
         public bool IsReverse { get; set; }
 
         /// <summary>
+        /// スペル名を非表示とするか？
+        /// </summary>
+        public bool HideSpellName { get; set; }
+        
+        /// <summary>
+        /// リキャストタイムを重ねて表示するか？
+        /// </summary>
+        public bool OverlapRecastTime { get; set; }
+
+        /// <summary>
         /// バーの色
         /// </summary>
         public string BarColor { get; set; }
@@ -164,6 +174,10 @@
                 tb.Stroke = this.FontOutlineBrush;
                 tb.StrokeThickness = 0.5d * tb.FontSize / 13.0d;
             }
+            if (this.HideSpellName)
+            {
+                tb.Visibility = System.Windows.Visibility.Collapsed;
+            }
 
             // リキャスト時間を描画する
             tb = this.RecastTimeTextBlock;
@@ -177,6 +191,11 @@
                 tb.Fill = this.FontBrush;
                 tb.Stroke = this.FontOutlineBrush;
                 tb.StrokeThickness = 0.5d * tb.FontSize / 13.0d;
+            }
+            if (this.OverlapRecastTime)
+            {
+                this.RecastTimePanel.SetValue(Grid.ColumnProperty, 0);
+                this.RecastTimePanel.SetValue(HorizontalAlignmentProperty, System.Windows.HorizontalAlignment.Center);
             }
 
             // ProgressBarを描画する

--- a/ACT.SpecialSpellTimer/SpellTimerControl.xaml.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerControl.xaml.cs
@@ -196,6 +196,7 @@
             {
                 this.RecastTimePanel.SetValue(Grid.ColumnProperty, 0);
                 this.RecastTimePanel.SetValue(HorizontalAlignmentProperty, System.Windows.HorizontalAlignment.Center);
+                this.RecastTimePanel.SetValue(VerticalAlignmentProperty, System.Windows.VerticalAlignment.Center);
             }
 
             // ProgressBarを描画する

--- a/ACT.SpecialSpellTimer/SpellTimerControl.xaml.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerControl.xaml.cs
@@ -6,6 +6,8 @@
 
     using ACT.SpecialSpellTimer.Properties;
     using ACT.SpecialSpellTimer.Utility;
+    using ACT.SpecialSpellTimer.Image;
+    using System.Windows.Media.Imaging;
 
     /// <summary>
     /// SpellTimerControl
@@ -33,6 +35,16 @@
         /// スペルのTitle
         /// </summary>
         public string SpellTitle { get; set; }
+
+        /// <summary>
+        /// スペルのIcon
+        /// </summary>
+        public string SpellIcon { get; set; }
+
+        /// <summary>
+        /// スペルIconサイズ
+        /// </summary>
+        public int SpellIconSize { get; set; }
 
         /// <summary>
         /// 残りリキャストTime(秒数)
@@ -132,6 +144,15 @@
             var tb = default(OutlineTextBlock);
             var font = this.FontInfo;
 
+            // アイコンを描画する
+            var image = this.SpellIconImage;
+            if (image.Source == null && this.SpellIcon != "")
+            {
+                image.Source = new BitmapImage(new System.Uri(IconController.Default.getIconFile(this.SpellIcon).FullPath));
+                image.Height = this.SpellIconSize;
+                image.Width = this.SpellIconSize;
+            }
+            
             // Titleを描画する
             tb = this.SpellTitleTextBlock;
             var title = string.IsNullOrWhiteSpace(this.SpellTitle) ? "　" : this.SpellTitle;

--- a/ACT.SpecialSpellTimer/SpellTimerListWindow.xaml.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerListWindow.xaml.cs
@@ -253,6 +253,8 @@
                 c.SpellIcon = spell.SpellIcon;
                 c.SpellIconSize = spell.SpellIconSize;
                 c.IsReverse = spell.IsReverse;
+                c.HideSpellName = spell.HideSpellName;
+                c.OverlapRecastTime = spell.OverlapRecastTime;
                 c.RecastTime = 0;
                 c.Progress = 1.0d;
 

--- a/ACT.SpecialSpellTimer/SpellTimerListWindow.xaml.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerListWindow.xaml.cs
@@ -250,6 +250,8 @@
                 c.SpellTitle = string.IsNullOrWhiteSpace(spell.SpellTitleReplaced) ?
                     spell.SpellTitle :
                     spell.SpellTitleReplaced;
+                c.SpellIcon = spell.SpellIcon;
+                c.SpellIconSize = spell.SpellIconSize;
                 c.IsReverse = spell.IsReverse;
                 c.RecastTime = 0;
                 c.Progress = 1.0d;

--- a/ACT.SpecialSpellTimer/SpellTimerTable.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerTable.cs
@@ -476,6 +476,7 @@
         {
             this.Panel = string.Empty;
             this.SpellTitle = string.Empty;
+            this.SpellIcon = string.Empty;
             this.Keyword = string.Empty;
             this.KeywordForExtend1 = string.Empty;
             this.KeywordForExtend2 = string.Empty;
@@ -505,6 +506,8 @@
         public long ID { get; set; }
         public string Panel { get; set; }
         public string SpellTitle { get; set; }
+        public string SpellIcon { get; set; }
+        public int SpellIconSize { get; set; }
         public string Keyword { get; set; }
         public string KeywordForExtend1 { get; set; }
         public string KeywordForExtend2 { get; set; }

--- a/ACT.SpecialSpellTimer/SpellTimerTable.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerTable.cs
@@ -544,6 +544,8 @@
         public string BackgroundColor { get; set; }
         public int BackgroundAlpha { get; set; }
         public bool DontHide { get; set; }
+        public bool HideSpellName { get; set; }
+        public bool OverlapRecastTime { get; set; }
         public bool RegexEnabled { get; set; }
         public string JobFilter { get; set; }
         public string ZoneFilter { get; set; }

--- a/ACT.SpecialSpellTimer/VisualSettingControl.Designer.cs
+++ b/ACT.SpecialSpellTimer/VisualSettingControl.Designer.cs
@@ -71,7 +71,7 @@
             this.SamplePictureBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.SamplePictureBox.Location = new System.Drawing.Point(3, 3);
             this.SamplePictureBox.Name = "SamplePictureBox";
-            this.SamplePictureBox.Size = new System.Drawing.Size(300, 50);
+            this.SamplePictureBox.Size = new System.Drawing.Size(300, 53);
             this.SamplePictureBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
             this.SamplePictureBox.TabIndex = 0;
             this.SamplePictureBox.TabStop = false;
@@ -97,105 +97,105 @@
             this.LoadColorSetItem,
             this.SaveColorSetItem});
             this.VisualSettingContextMenuStrip.Name = "ContextMenuStrip";
-            this.VisualSettingContextMenuStrip.Size = new System.Drawing.Size(229, 330);
+            this.VisualSettingContextMenuStrip.Size = new System.Drawing.Size(218, 330);
             // 
             // ChangeFontItem
             // 
             this.ChangeFontItem.Name = "ChangeFontItem";
-            this.ChangeFontItem.Size = new System.Drawing.Size(228, 22);
+            this.ChangeFontItem.Size = new System.Drawing.Size(217, 22);
             this.ChangeFontItem.Text = "ChangeFont";
             // 
             // ChangeFontColorItem
             // 
             this.ChangeFontColorItem.Name = "ChangeFontColorItem";
-            this.ChangeFontColorItem.Size = new System.Drawing.Size(228, 22);
+            this.ChangeFontColorItem.Size = new System.Drawing.Size(217, 22);
             this.ChangeFontColorItem.Text = "ChangeFontColor";
             // 
             // ChangeFontOutlineColorItem
             // 
             this.ChangeFontOutlineColorItem.Name = "ChangeFontOutlineColorItem";
-            this.ChangeFontOutlineColorItem.Size = new System.Drawing.Size(228, 22);
+            this.ChangeFontOutlineColorItem.Size = new System.Drawing.Size(217, 22);
             this.ChangeFontOutlineColorItem.Text = "ChangeFontOutlineColor";
             // 
             // ChangeBarColorItem
             // 
             this.ChangeBarColorItem.Name = "ChangeBarColorItem";
-            this.ChangeBarColorItem.Size = new System.Drawing.Size(228, 22);
+            this.ChangeBarColorItem.Size = new System.Drawing.Size(217, 22);
             this.ChangeBarColorItem.Text = "ChangeBarColor";
             // 
             // ChangeBarOutlineColorItem
             // 
             this.ChangeBarOutlineColorItem.Name = "ChangeBarOutlineColorItem";
-            this.ChangeBarOutlineColorItem.Size = new System.Drawing.Size(228, 22);
+            this.ChangeBarOutlineColorItem.Size = new System.Drawing.Size(217, 22);
             this.ChangeBarOutlineColorItem.Text = "ChangeBarOutlineColor";
             // 
             // ChangeBackgoundColorItem
             // 
             this.ChangeBackgoundColorItem.Name = "ChangeBackgoundColorItem";
-            this.ChangeBackgoundColorItem.Size = new System.Drawing.Size(228, 22);
+            this.ChangeBackgoundColorItem.Size = new System.Drawing.Size(217, 22);
             this.ChangeBackgoundColorItem.Text = "ChangeBackgroundColor";
             // 
             // ChangeBackgroundAlphaItem
             // 
             this.ChangeBackgroundAlphaItem.Name = "ChangeBackgroundAlphaItem";
-            this.ChangeBackgroundAlphaItem.Size = new System.Drawing.Size(228, 22);
+            this.ChangeBackgroundAlphaItem.Size = new System.Drawing.Size(217, 22);
             this.ChangeBackgroundAlphaItem.Text = "ChangeBackgroundAlpha";
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(225, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(214, 6);
             // 
             // ResetSpellFontItem
             // 
             this.ResetSpellFontItem.Name = "ResetSpellFontItem";
-            this.ResetSpellFontItem.Size = new System.Drawing.Size(228, 22);
+            this.ResetSpellFontItem.Size = new System.Drawing.Size(217, 22);
             this.ResetSpellFontItem.Text = "ResetSpellFont";
             // 
             // ResetSpellBarSizeItem
             // 
             this.ResetSpellBarSizeItem.Name = "ResetSpellBarSizeItem";
-            this.ResetSpellBarSizeItem.Size = new System.Drawing.Size(228, 22);
+            this.ResetSpellBarSizeItem.Size = new System.Drawing.Size(217, 22);
             this.ResetSpellBarSizeItem.Text = "ResetSpellBarSize";
             // 
             // ResetSpellColorItem
             // 
             this.ResetSpellColorItem.Name = "ResetSpellColorItem";
-            this.ResetSpellColorItem.Size = new System.Drawing.Size(228, 22);
+            this.ResetSpellColorItem.Size = new System.Drawing.Size(217, 22);
             this.ResetSpellColorItem.Text = "ResetSpellColor";
             // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(225, 6);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(214, 6);
             // 
             // ResetTelopFontItem
             // 
             this.ResetTelopFontItem.Name = "ResetTelopFontItem";
-            this.ResetTelopFontItem.Size = new System.Drawing.Size(228, 22);
+            this.ResetTelopFontItem.Size = new System.Drawing.Size(217, 22);
             this.ResetTelopFontItem.Text = "ResetTelopFont";
             // 
             // ResetTelopColorItem
             // 
             this.ResetTelopColorItem.Name = "ResetTelopColorItem";
-            this.ResetTelopColorItem.Size = new System.Drawing.Size(228, 22);
+            this.ResetTelopColorItem.Size = new System.Drawing.Size(217, 22);
             this.ResetTelopColorItem.Text = "ResetTelopColor";
             // 
             // toolStripSeparator3
             // 
             this.toolStripSeparator3.Name = "toolStripSeparator3";
-            this.toolStripSeparator3.Size = new System.Drawing.Size(225, 6);
+            this.toolStripSeparator3.Size = new System.Drawing.Size(214, 6);
             // 
             // LoadColorSetItem
             // 
             this.LoadColorSetItem.Name = "LoadColorSetItem";
-            this.LoadColorSetItem.Size = new System.Drawing.Size(228, 22);
+            this.LoadColorSetItem.Size = new System.Drawing.Size(217, 22);
             this.LoadColorSetItem.Text = "LoadColorSet";
             // 
             // SaveColorSetItem
             // 
             this.SaveColorSetItem.Name = "SaveColorSetItem";
-            this.SaveColorSetItem.Size = new System.Drawing.Size(228, 22);
+            this.SaveColorSetItem.Size = new System.Drawing.Size(217, 22);
             this.SaveColorSetItem.Text = "SaveColorSet";
             // 
             // BarSizeLabel

--- a/ACT.SpecialSpellTimer/VisualSettingControl.cs
+++ b/ACT.SpecialSpellTimer/VisualSettingControl.cs
@@ -12,6 +12,8 @@
 
     using ACT.SpecialSpellTimer.Properties;
     using ACT.SpecialSpellTimer.Utility;
+    using ACT.SpecialSpellTimer.Image;
+    using System.Windows.Media.Imaging;
 
     /// <summary>
     /// 見た目設定用コントロール
@@ -65,6 +67,8 @@
             this.BarColor = Settings.Default.ProgressBarColor;
             this.BarOutlineColor = Settings.Default.ProgressBarOutlineColor;
             this.BarSize = Settings.Default.ProgressBarSize;
+
+            this.SpellIcon = "";
 
             this.BarEnabled = true;
 
@@ -310,6 +314,14 @@
             this.fontInfo = fontInfo;
         }
 
+        public String SpellIcon { get; set; }
+
+        public int SpellIconSize { get; set; }
+
+        public bool HideSpellName { get; set; }
+
+        public bool OverlapRecastTime { get; set; }
+
         public Color FontColor { get; set; }
 
         public Color FontOutlineColor { get; set; }
@@ -429,13 +441,26 @@
                     outlinePen.Dispose();
                 }
 
+                // アイコンを描く
+                var hasIcon = false;
+                if (this.BarEnabled)
+                {
+                    var spellIcon = IconController.Default.getIconFile(this.SpellIcon);
+                    if (spellIcon != null) {
+                        var image = System.Drawing.Image.FromFile(spellIcon.FullPath);
+                        g.DrawImage(image, barLocation.X, barLocation.Y - this.SpellIconSize, (float)this.SpellIconSize, (float)this.SpellIconSize);
+                        hasIcon = true;
+                    }
+                }
+ 
                 // フォントのペンを生成する
                 var fontBrush = new SolidBrush(fontColor);
                 var fontOutlinePen = new Pen(fontOutlineColor, 0.2f);
+                var fontHeight = font.Size * 2; // 正しくない計算
                 var fontRect = new Rectangle(
-                    barLocation.X,
-                    6,
-                    barSize.Width,
+                    hasIcon ? barLocation.X + this.SpellIconSize : barLocation.X,
+                    barLocation.Y - 2 - (int)fontHeight,
+                    hasIcon ? barSize.Width - this.SpellIconSize : barSize.Width,
                     barLocation.Y - 2);
 
                 if (!this.BarEnabled)
@@ -455,7 +480,7 @@
 
                 var recastSf = new StringFormat()
                 {
-                    Alignment = StringAlignment.Far
+                    Alignment = this.OverlapRecastTime ? StringAlignment.Near : StringAlignment.Far
                 };
 
                 var telopSf = new StringFormat()
@@ -467,14 +492,21 @@
 
                 if (this.BarEnabled)
                 {
-                    path.AddString(
-                        Translate.Get("SampleSpell"),
-                        font.FontFamily,
-                        (int)font.Style,
-                        (float)font.ToFontSizeWPF(),
-                        fontRect,
-                        spellSf);
+                    if (!this.HideSpellName)
+                    {
+                        path.AddString(
+                            Translate.Get("SampleSpell"),
+                            font.FontFamily,
+                            (int)font.Style,
+                            (float)font.ToFontSizeWPF(),
+                            fontRect,
+                            spellSf);
+                    }
 
+                    if (this.OverlapRecastTime)
+                    {
+                        fontRect.X = barLocation.X;
+                    }
                     path.AddString(
                         "120.0",
                         font.FontFamily,

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-EN.Designer.cs
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-EN.Designer.cs
@@ -691,6 +691,15 @@ namespace ACT.SpecialSpellTimer.resources.strings {
         }
         
         /// <summary>
+        ///   Hide Spell Name に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string HideSpellNameCheckBox {
+            get {
+                return ResourceManager.GetString("HideSpellNameCheckBox", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   HP に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string HPHeader {
@@ -984,6 +993,15 @@ namespace ACT.SpecialSpellTimer.resources.strings {
         internal static string OptionTabPageTitle {
             get {
                 return ResourceManager.GetString("OptionTabPageTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Overlap Recast Time に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string OverlapRecastTimeCheckBox {
+            get {
+                return ResourceManager.GetString("OverlapRecastTimeCheckBox", resourceCulture);
             }
         }
         

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-EN.Designer.cs
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-EN.Designer.cs
@@ -1474,6 +1474,24 @@ namespace ACT.SpecialSpellTimer.resources.strings {
         }
         
         /// <summary>
+        ///   Spell Icon に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string SpellIconLabel {
+            get {
+                return ResourceManager.GetString("SpellIconLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Size of Spell Icon に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string SpellIconSizeLabel {
+            get {
+                return ResourceManager.GetString("SpellIconSizeLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Spell name に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string SpellNameLabel {

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-EN.resx
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-EN.resx
@@ -865,4 +865,12 @@
     <value>Export...</value>
     <comment>CSV保存</comment>
   </data>
+  <data name="SpellIconLabel" xml:space="preserve">
+    <value>Spell Icon</value>
+    <comment>スペルのアイコン</comment>
+  </data>
+  <data name="SpellIconSizeLabel" xml:space="preserve">
+    <value>Size of Spell Icon</value>
+    <comment>スペルアイコンのサイズ</comment>
+  </data>
 </root>

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-EN.resx
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-EN.resx
@@ -873,4 +873,12 @@
     <value>Size of Spell Icon</value>
     <comment>スペルアイコンのサイズ</comment>
   </data>
+  <data name="HideSpellNameCheckBox" xml:space="preserve">
+    <value>Hide Spell Name</value>
+    <comment>スペル名を表示しない</comment>
+  </data>
+  <data name="OverlapRecastTimeCheckBox" xml:space="preserve">
+    <value>Overlap Recast Time</value>
+    <comment>リキャストタイムを重ねる</comment>
+  </data>
 </root>

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-JP.Designer.cs
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-JP.Designer.cs
@@ -1474,6 +1474,24 @@ namespace ACT.SpecialSpellTimer.resources.strings {
         }
         
         /// <summary>
+        ///   スペルのアイコン に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string SpellIconLabel {
+            get {
+                return ResourceManager.GetString("SpellIconLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   スペルアイコンのサイズ に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string SpellIconSizeLabel {
+            get {
+                return ResourceManager.GetString("SpellIconSizeLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   スペルの名前 に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string SpellNameLabel {

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-JP.Designer.cs
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-JP.Designer.cs
@@ -691,6 +691,15 @@ namespace ACT.SpecialSpellTimer.resources.strings {
         }
         
         /// <summary>
+        ///   スペル名を表示しない に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string HideSpellNameCheckBox {
+            get {
+                return ResourceManager.GetString("HideSpellNameCheckBox", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   HP に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string HPHeader {
@@ -984,6 +993,15 @@ namespace ACT.SpecialSpellTimer.resources.strings {
         internal static string OptionTabPageTitle {
             get {
                 return ResourceManager.GetString("OptionTabPageTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   リキャストタイムを重ねる に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string OverlapRecastTimeCheckBox {
+            get {
+                return ResourceManager.GetString("OverlapRecastTimeCheckBox", resourceCulture);
             }
         }
         

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-JP.resx
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-JP.resx
@@ -873,4 +873,12 @@
     <value>スペルアイコンのサイズ</value>
     <comment>Size of Spell Icon</comment>
   </data>
+  <data name="HideSpellNameCheckBox" xml:space="preserve">
+    <value>スペル名を表示しない</value>
+    <comment>Hide Spell Name</comment>
+  </data>
+  <data name="OverlapRecastTimeCheckBox" xml:space="preserve">
+    <value>リキャストタイムを重ねる</value>
+    <comment>Overlap Recast time </comment>
+  </data>
 </root>

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-JP.resx
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-JP.resx
@@ -865,4 +865,12 @@
     <value>CSV保存</value>
     <comment>Export to CSV</comment>
   </data>
+  <data name="SpellIconLabel" xml:space="preserve">
+    <value>スペルのアイコン</value>
+    <comment>Spell Icon</comment>
+  </data>
+  <data name="SpellIconSizeLabel" xml:space="preserve">
+    <value>スペルアイコンのサイズ</value>
+    <comment>Size of Spell Icon</comment>
+  </data>
 </root>


### PR DESCRIPTION
スペルタイマーの各スペルにアイコンを設定できるようにしました。
またアイコン表示と合わせて利用するために、以下の表示オプションを追加しました。

　・スペル名を表示しない
　・リキャストタイムをアイコンに重ねる

これらの組み合わせにより、添付画像のような表示が可能となります。

![spell-icon](https://cloud.githubusercontent.com/assets/379664/9329806/c158e430-45ef-11e5-8ee0-79e059158a45.png)

アイコンを付けて視認性を向上させる、アイコンのみにして表示領域をコンパクトにする、
などを実現することが目的です。
