### PR TITLE
アイコン描画に関する改善を行いました

### DIFF
--- a/ACT.SpecialSpellTimer/ConfigPanel.Designer.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.Designer.cs
@@ -32,6 +32,7 @@
             this.TabControl = new System.Windows.Forms.TabControl();
             this.SpecialSpellTabPage = new System.Windows.Forms.TabPage();
             this.DetailPanelGroupBox = new System.Windows.Forms.GroupBox();
+            this.FixedPositionSpellCheckBox = new System.Windows.Forms.CheckBox();
             this.HorizontalLayoutCheckBox = new System.Windows.Forms.CheckBox();
             this.label62 = new System.Windows.Forms.Label();
             this.MarginUpDown = new System.Windows.Forms.NumericUpDown();
@@ -45,6 +46,7 @@
             this.DetailGroupBox = new System.Windows.Forms.GroupBox();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.ReduceIconBrightnessCheckBox = new System.Windows.Forms.CheckBox();
             this.OverlapRecastTimeCheckBox = new System.Windows.Forms.CheckBox();
             this.HideSpellNameCheckBox = new System.Windows.Forms.CheckBox();
             this.SpellIconSizeUpDown = new System.Windows.Forms.NumericUpDown();
@@ -64,6 +66,7 @@
             this.ExpandSecounds1NumericUpDown = new System.Windows.Forms.NumericUpDown();
             this.KeywordToExpand1TextBox = new System.Windows.Forms.TextBox();
             this.label50 = new System.Windows.Forms.Label();
+            this.SpellVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
             this.RegexEnabledCheckBox = new System.Windows.Forms.CheckBox();
             this.DontHideCheckBox = new System.Windows.Forms.CheckBox();
             this.label27 = new System.Windows.Forms.Label();
@@ -124,6 +127,7 @@
             this.OnPointTelopTabPage = new System.Windows.Forms.TabPage();
             this.TelopDetailGroupBox = new System.Windows.Forms.GroupBox();
             this.TelopSelectZoneButton = new System.Windows.Forms.Button();
+            this.TelopVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
             this.TelopSelectJobButton = new System.Windows.Forms.Button();
             this.TelopProgressBarEnabledCheckBox = new System.Windows.Forms.CheckBox();
             this.EnabledAddMessageCheckBox = new System.Windows.Forms.CheckBox();
@@ -226,15 +230,12 @@
             this.label18 = new System.Windows.Forms.Label();
             this.SwitchOverlayButton = new System.Windows.Forms.Button();
             this.ShokikaButton = new System.Windows.Forms.Button();
+            this.DefaultVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
             this.OpenFileDialog = new System.Windows.Forms.OpenFileDialog();
             this.SaveFileDialog = new System.Windows.Forms.SaveFileDialog();
             this.ToolTip = new System.Windows.Forms.ToolTip(this.components);
             this.CombatAnalyzingTimer = new System.Windows.Forms.Timer(this.components);
             this.EnabledSpellTimerNoDecimal = new System.Windows.Forms.CheckBox();
-            this.SpellVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
-            this.TelopVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
-            this.DefaultVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
-            this.FixedPositionSpellCheckBox = new System.Windows.Forms.CheckBox();
             this.TabControl.SuspendLayout();
             this.SpecialSpellTabPage.SuspendLayout();
             this.DetailPanelGroupBox.SuspendLayout();
@@ -323,6 +324,16 @@
             this.DetailPanelGroupBox.Size = new System.Drawing.Size(296, 269);
             this.DetailPanelGroupBox.TabIndex = 6;
             this.DetailPanelGroupBox.TabStop = false;
+            // 
+            // FixedPositionSpellCheckBox
+            // 
+            this.FixedPositionSpellCheckBox.AutoSize = true;
+            this.FixedPositionSpellCheckBox.Location = new System.Drawing.Point(9, 110);
+            this.FixedPositionSpellCheckBox.Name = "FixedPositionSpellCheckBox";
+            this.FixedPositionSpellCheckBox.Size = new System.Drawing.Size(118, 16);
+            this.FixedPositionSpellCheckBox.TabIndex = 47;
+            this.FixedPositionSpellCheckBox.Text = "FixedPositionSpell";
+            this.FixedPositionSpellCheckBox.UseVisualStyleBackColor = true;
             // 
             // HorizontalLayoutCheckBox
             // 
@@ -479,6 +490,7 @@
             // 
             // tabPage1
             // 
+            this.tabPage1.Controls.Add(this.ReduceIconBrightnessCheckBox);
             this.tabPage1.Controls.Add(this.OverlapRecastTimeCheckBox);
             this.tabPage1.Controls.Add(this.HideSpellNameCheckBox);
             this.tabPage1.Controls.Add(this.SpellIconSizeUpDown);
@@ -522,6 +534,16 @@
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "GeneralTab";
             this.tabPage1.UseVisualStyleBackColor = true;
+            // 
+            // ReduceIconBrightnessCheckBox
+            // 
+            this.ReduceIconBrightnessCheckBox.AutoSize = true;
+            this.ReduceIconBrightnessCheckBox.Location = new System.Drawing.Point(519, 377);
+            this.ReduceIconBrightnessCheckBox.Name = "ReduceIconBrightnessCheckBox";
+            this.ReduceIconBrightnessCheckBox.Size = new System.Drawing.Size(190, 16);
+            this.ReduceIconBrightnessCheckBox.TabIndex = 72;
+            this.ReduceIconBrightnessCheckBox.Text = "ReduceIconBrightnessCheckBox";
+            this.ReduceIconBrightnessCheckBox.UseVisualStyleBackColor = true;
             // 
             // OverlapRecastTimeCheckBox
             // 
@@ -734,6 +756,24 @@
             this.label50.Size = new System.Drawing.Size(171, 12);
             this.label50.TabIndex = 52;
             this.label50.Text = "MatchingLogWordToExpandLabel";
+            // 
+            // SpellVisualSetting
+            // 
+            this.SpellVisualSetting.BackgroundColor = System.Drawing.Color.Empty;
+            this.SpellVisualSetting.BarColor = System.Drawing.Color.White;
+            this.SpellVisualSetting.BarEnabled = true;
+            this.SpellVisualSetting.BarOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
+            this.SpellVisualSetting.BarSize = new System.Drawing.Size(190, 8);
+            this.SpellVisualSetting.FontColor = System.Drawing.Color.White;
+            this.SpellVisualSetting.FontOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
+            this.SpellVisualSetting.HideSpellName = false;
+            this.SpellVisualSetting.Location = new System.Drawing.Point(195, 262);
+            this.SpellVisualSetting.Name = "SpellVisualSetting";
+            this.SpellVisualSetting.OverlapRecastTime = false;
+            this.SpellVisualSetting.Size = new System.Drawing.Size(306, 109);
+            this.SpellVisualSetting.SpellIcon = "";
+            this.SpellVisualSetting.SpellIconSize = 0;
+            this.SpellVisualSetting.TabIndex = 51;
             // 
             // RegexEnabledCheckBox
             // 
@@ -1393,6 +1433,24 @@
             this.TelopSelectZoneButton.TabIndex = 46;
             this.TelopSelectZoneButton.Text = "SelectZoneButton";
             this.TelopSelectZoneButton.UseVisualStyleBackColor = true;
+            // 
+            // TelopVisualSetting
+            // 
+            this.TelopVisualSetting.BackgroundColor = System.Drawing.Color.Empty;
+            this.TelopVisualSetting.BarColor = System.Drawing.Color.White;
+            this.TelopVisualSetting.BarEnabled = false;
+            this.TelopVisualSetting.BarOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
+            this.TelopVisualSetting.BarSize = new System.Drawing.Size(190, 8);
+            this.TelopVisualSetting.FontColor = System.Drawing.Color.White;
+            this.TelopVisualSetting.FontOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
+            this.TelopVisualSetting.HideSpellName = false;
+            this.TelopVisualSetting.Location = new System.Drawing.Point(187, 143);
+            this.TelopVisualSetting.Name = "TelopVisualSetting";
+            this.TelopVisualSetting.OverlapRecastTime = false;
+            this.TelopVisualSetting.Size = new System.Drawing.Size(306, 71);
+            this.TelopVisualSetting.SpellIcon = "";
+            this.TelopVisualSetting.SpellIconSize = 0;
+            this.TelopVisualSetting.TabIndex = 6;
             // 
             // TelopSelectJobButton
             // 
@@ -2442,6 +2500,24 @@
             this.ShokikaButton.UseVisualStyleBackColor = true;
             this.ShokikaButton.Click += new System.EventHandler(this.ShokikaButton_Click);
             // 
+            // DefaultVisualSetting
+            // 
+            this.DefaultVisualSetting.BackgroundColor = System.Drawing.Color.Empty;
+            this.DefaultVisualSetting.BarColor = System.Drawing.Color.White;
+            this.DefaultVisualSetting.BarEnabled = true;
+            this.DefaultVisualSetting.BarOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
+            this.DefaultVisualSetting.BarSize = new System.Drawing.Size(190, 8);
+            this.DefaultVisualSetting.FontColor = System.Drawing.Color.White;
+            this.DefaultVisualSetting.FontOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
+            this.DefaultVisualSetting.HideSpellName = false;
+            this.DefaultVisualSetting.Location = new System.Drawing.Point(293, 108);
+            this.DefaultVisualSetting.Name = "DefaultVisualSetting";
+            this.DefaultVisualSetting.OverlapRecastTime = false;
+            this.DefaultVisualSetting.Size = new System.Drawing.Size(306, 71);
+            this.DefaultVisualSetting.SpellIcon = "";
+            this.DefaultVisualSetting.SpellIconSize = 0;
+            this.DefaultVisualSetting.TabIndex = 37;
+            // 
             // OpenFileDialog
             // 
             this.OpenFileDialog.DefaultExt = "xml";
@@ -2473,70 +2549,6 @@
             this.EnabledSpellTimerNoDecimal.TabIndex = 42;
             this.EnabledSpellTimerNoDecimal.Text = "Enabled";
             this.EnabledSpellTimerNoDecimal.UseVisualStyleBackColor = true;
-            // 
-            // SpellVisualSetting
-            // 
-            this.SpellVisualSetting.BackgroundColor = System.Drawing.Color.Empty;
-            this.SpellVisualSetting.BarColor = System.Drawing.Color.White;
-            this.SpellVisualSetting.BarEnabled = true;
-            this.SpellVisualSetting.BarOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
-            this.SpellVisualSetting.BarSize = new System.Drawing.Size(190, 8);
-            this.SpellVisualSetting.FontColor = System.Drawing.Color.White;
-            this.SpellVisualSetting.FontOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
-            this.SpellVisualSetting.HideSpellName = false;
-            this.SpellVisualSetting.Location = new System.Drawing.Point(195, 262);
-            this.SpellVisualSetting.Name = "SpellVisualSetting";
-            this.SpellVisualSetting.OverlapRecastTime = false;
-            this.SpellVisualSetting.Size = new System.Drawing.Size(306, 109);
-            this.SpellVisualSetting.SpellIcon = "";
-            this.SpellVisualSetting.SpellIconSize = 0;
-            this.SpellVisualSetting.TabIndex = 51;
-            // 
-            // TelopVisualSetting
-            // 
-            this.TelopVisualSetting.BackgroundColor = System.Drawing.Color.Empty;
-            this.TelopVisualSetting.BarColor = System.Drawing.Color.White;
-            this.TelopVisualSetting.BarEnabled = false;
-            this.TelopVisualSetting.BarOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
-            this.TelopVisualSetting.BarSize = new System.Drawing.Size(190, 8);
-            this.TelopVisualSetting.FontColor = System.Drawing.Color.White;
-            this.TelopVisualSetting.FontOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
-            this.TelopVisualSetting.HideSpellName = false;
-            this.TelopVisualSetting.Location = new System.Drawing.Point(187, 143);
-            this.TelopVisualSetting.Name = "TelopVisualSetting";
-            this.TelopVisualSetting.OverlapRecastTime = false;
-            this.TelopVisualSetting.Size = new System.Drawing.Size(306, 71);
-            this.TelopVisualSetting.SpellIcon = "";
-            this.TelopVisualSetting.SpellIconSize = 0;
-            this.TelopVisualSetting.TabIndex = 6;
-            // 
-            // DefaultVisualSetting
-            // 
-            this.DefaultVisualSetting.BackgroundColor = System.Drawing.Color.Empty;
-            this.DefaultVisualSetting.BarColor = System.Drawing.Color.White;
-            this.DefaultVisualSetting.BarEnabled = true;
-            this.DefaultVisualSetting.BarOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
-            this.DefaultVisualSetting.BarSize = new System.Drawing.Size(190, 8);
-            this.DefaultVisualSetting.FontColor = System.Drawing.Color.White;
-            this.DefaultVisualSetting.FontOutlineColor = System.Drawing.Color.FromArgb(((int)(((byte)(22)))), ((int)(((byte)(120)))), ((int)(((byte)(157)))));
-            this.DefaultVisualSetting.HideSpellName = false;
-            this.DefaultVisualSetting.Location = new System.Drawing.Point(293, 108);
-            this.DefaultVisualSetting.Name = "DefaultVisualSetting";
-            this.DefaultVisualSetting.OverlapRecastTime = false;
-            this.DefaultVisualSetting.Size = new System.Drawing.Size(306, 71);
-            this.DefaultVisualSetting.SpellIcon = "";
-            this.DefaultVisualSetting.SpellIconSize = 0;
-            this.DefaultVisualSetting.TabIndex = 37;
-            // 
-            // FixedPositionSpellCheckBox
-            // 
-            this.FixedPositionSpellCheckBox.AutoSize = true;
-            this.FixedPositionSpellCheckBox.Location = new System.Drawing.Point(9, 110);
-            this.FixedPositionSpellCheckBox.Name = "FixedPositionSpellCheckBox";
-            this.FixedPositionSpellCheckBox.Size = new System.Drawing.Size(118, 16);
-            this.FixedPositionSpellCheckBox.TabIndex = 47;
-            this.FixedPositionSpellCheckBox.Text = "FixedPositionSpell";
-            this.FixedPositionSpellCheckBox.UseVisualStyleBackColor = true;
             // 
             // ConfigPanel
             // 
@@ -2805,5 +2817,6 @@
         private System.Windows.Forms.NumericUpDown MarginUpDown;
         private System.Windows.Forms.CheckBox HorizontalLayoutCheckBox;
         private System.Windows.Forms.CheckBox FixedPositionSpellCheckBox;
+        private System.Windows.Forms.CheckBox ReduceIconBrightnessCheckBox;
     }
 }

--- a/ACT.SpecialSpellTimer/ConfigPanel.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.cs
@@ -281,6 +281,7 @@
                         nr.DontHide = baseRow.DontHide;
                         nr.HideSpellName = baseRow.HideSpellName;
                         nr.OverlapRecastTime = baseRow.OverlapRecastTime;
+                        nr.ReduceIconBrightness = baseRow.ReduceIconBrightness;
                         nr.FontFamily = baseRow.FontFamily;
                         nr.FontSize = baseRow.FontSize;
                         nr.FontStyle = baseRow.FontStyle;
@@ -409,6 +410,7 @@
                     src.DontHide = this.DontHideCheckBox.Checked;
                     src.HideSpellName = this.HideSpellNameCheckBox.Checked;
                     src.OverlapRecastTime = this.OverlapRecastTimeCheckBox.Checked;
+                    src.ReduceIconBrightness = this.ReduceIconBrightnessCheckBox.Checked;
 
                     src.Font = this.SpellVisualSetting.GetFontInfo();
                     src.FontColor = this.SpellVisualSetting.FontColor.ToHTML();
@@ -688,6 +690,7 @@
             this.DontHideCheckBox.Checked = src.DontHide;
             this.HideSpellNameCheckBox.Checked = src.HideSpellName;
             this.OverlapRecastTimeCheckBox.Checked = src.OverlapRecastTime;
+            this.ReduceIconBrightnessCheckBox.Checked = src.ReduceIconBrightness;
 
             this.SpellVisualSetting.SetFontInfo(src.Font);
             this.SpellVisualSetting.BarColor = string.IsNullOrWhiteSpace(src.BarColor) ?

--- a/ACT.SpecialSpellTimer/SpellTimerControl.xaml
+++ b/ACT.SpecialSpellTimer/SpellTimerControl.xaml
@@ -71,7 +71,7 @@
       </Utility:OutlineTextBlock>
     </DockPanel>
 
-    <DockPanel x:Name="RecastTimePanel" Grid.Row="0" Grid.Column="2" HorizontalAlignment="Right" VerticalAlignment="Bottom">
+    <Viewbox x:Name="RecastTimePanel" Grid.Row="0" Grid.Column="2" HorizontalAlignment="Right" VerticalAlignment="Bottom" StretchDirection="DownOnly" Stretch="Uniform">
       <Utility:OutlineTextBlock
         x:Name="RecastTimeTextBlock" 
         HorizontalAlignment="Right" 
@@ -92,7 +92,7 @@
             Color="{Binding ElementName=RecastTimeTextBlock, Path=Stroke.Color, Mode=OneWay}" />
         </Utility:OutlineTextBlock.Effect>
       </Utility:OutlineTextBlock>
-    </DockPanel>
+    </Viewbox>
     
   </Grid>
 </UserControl>

--- a/ACT.SpecialSpellTimer/SpellTimerControl.xaml
+++ b/ACT.SpecialSpellTimer/SpellTimerControl.xaml
@@ -46,7 +46,7 @@
       <Rectangle x:Name="BarOutlineRectangle" />
     </Canvas>
 
-    <DockPanel Grid.Row="0" Grid.Column="0" Panel.ZIndex="-1">
+    <DockPanel x:Name="SpellIconPanel" Grid.Column="0" Panel.ZIndex="-1" Background="Black">
       <Image x:Name="SpellIconImage"></Image>
     </DockPanel>
 

--- a/ACT.SpecialSpellTimer/SpellTimerControl.xaml.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerControl.xaml.cs
@@ -72,6 +72,11 @@
         public bool OverlapRecastTime { get; set; }
 
         /// <summary>
+        /// リキャスト中にアイコンの明度を下げるか？
+        /// </summary>
+        public bool ReduceIconBrightness { get; set; }
+
+        /// <summary>
         /// バーの色
         /// </summary>
         public string BarColor { get; set; }
@@ -159,11 +164,31 @@
             var iconFile = IconController.Default.getIconFile(this.SpellIcon);
             if (image.Source == null && iconFile != null)
             {
-                image.Source = new BitmapImage(new System.Uri(iconFile.FullPath));
+                var bitmap = new BitmapImage(new System.Uri(iconFile.FullPath));
+                image.Source = bitmap;
                 image.Height = this.SpellIconSize;
                 image.Width = this.SpellIconSize;
+
+                this.SpellIconPanel.OpacityMask = new ImageBrush(bitmap);
             }
-            
+
+            // アイコンの不透明度を設定する
+            if (this.ReduceIconBrightness)
+            {
+                if (this.RecastTime > 0)
+                {
+                    image.Opacity = this.IsReverse ? 1.0 : 0.6;
+                }
+                else
+                {
+                    image.Opacity = this.IsReverse ? 0.6 : 1.0;
+                }
+            }
+            else
+            {
+                image.Opacity = 1.0;
+            }
+
             // Titleを描画する
             tb = this.SpellTitleTextBlock;
             var title = string.IsNullOrWhiteSpace(this.SpellTitle) ? "　" : this.SpellTitle;

--- a/ACT.SpecialSpellTimer/SpellTimerControl.xaml.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerControl.xaml.cs
@@ -197,6 +197,13 @@
                 this.RecastTimePanel.SetValue(Grid.ColumnProperty, 0);
                 this.RecastTimePanel.SetValue(HorizontalAlignmentProperty, System.Windows.HorizontalAlignment.Center);
                 this.RecastTimePanel.SetValue(VerticalAlignmentProperty, System.Windows.VerticalAlignment.Center);
+                this.RecastTimePanel.Width = this.SpellIconSize - 6;
+                this.RecastTimePanel.Height = this.SpellIconSize - 6;
+            }
+            else
+            {
+                this.RecastTimePanel.Width = double.NaN;
+                this.RecastTimePanel.Height = double.NaN;
             }
 
             // ProgressBarを描画する

--- a/ACT.SpecialSpellTimer/SpellTimerControl.xaml.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerControl.xaml.cs
@@ -156,9 +156,10 @@
 
             // アイコンを描画する
             var image = this.SpellIconImage;
-            if (image.Source == null && this.SpellIcon != "")
+            var iconFile = IconController.Default.getIconFile(this.SpellIcon);
+            if (image.Source == null && iconFile != null)
             {
-                image.Source = new BitmapImage(new System.Uri(IconController.Default.getIconFile(this.SpellIcon).FullPath));
+                image.Source = new BitmapImage(new System.Uri(iconFile.FullPath));
                 image.Height = this.SpellIconSize;
                 image.Width = this.SpellIconSize;
             }

--- a/ACT.SpecialSpellTimer/SpellTimerListWindow.xaml
+++ b/ACT.SpecialSpellTimer/SpellTimerListWindow.xaml
@@ -10,7 +10,6 @@
   >
 
   <Grid Name="BackgroundColorGrid">
-
     <Canvas
       Margin="0,0,0,0">
       <Rectangle
@@ -26,6 +25,12 @@
     </Canvas>
 
     <Grid Name="BaseGrid" Margin="8,6,6,6">
+      <Grid.RowDefinitions>
+        <RowDefinition Height="Auto"/>
+      </Grid.RowDefinitions>
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="Auto"/>
+      </Grid.ColumnDefinitions>
     </Grid>
 
   </Grid>

--- a/ACT.SpecialSpellTimer/SpellTimerListWindow.xaml.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerListWindow.xaml.cs
@@ -280,6 +280,7 @@
                 c.IsReverse = spell.IsReverse;
                 c.HideSpellName = spell.HideSpellName;
                 c.OverlapRecastTime = spell.OverlapRecastTime;
+                c.ReduceIconBrightness = spell.ReduceIconBrightness;
                 c.RecastTime = 0;
                 c.Progress = 1.0d;
 

--- a/ACT.SpecialSpellTimer/SpellTimerListWindow.xaml.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerListWindow.xaml.cs
@@ -264,8 +264,6 @@
                     c.VerticalAlignment = VerticalAlignment.Top;
                     c.Margin = new Thickness(0, 0, 0, 0);
 
-                    this.BaseGrid.RowDefinitions.Add(new RowDefinition());
-                    this.BaseGrid.ColumnDefinitions.Add(new ColumnDefinition());
                     this.BaseGrid.Children.Add(c);
 
                     c.SetValue(Grid.ColumnProperty, 0);
@@ -330,6 +328,37 @@
                 if (!spells.Any(x => x.ID == c.Key))
                 {
                     c.Value.Visibility = Visibility.Collapsed;
+                }
+            }
+
+            // 行・列の個数がスペル表示数より小さい場合に拡張する
+            // また不要な行・列を削除する
+            if (this.IsHorizontal)
+            {
+                if (this.BaseGrid.RowDefinitions.Count > 1)
+                {
+                    this.BaseGrid.RowDefinitions.RemoveRange(1, this.BaseGrid.RowDefinitions.Count - 1);
+                }
+
+                for (int i = 0; i < (displayList.Count - this.BaseGrid.ColumnDefinitions.Count); i++)
+                {
+                    var column = new ColumnDefinition();
+                    column.Width = GridLength.Auto;
+                    this.BaseGrid.ColumnDefinitions.Add(column);
+                }
+            }
+            else
+            {
+                if (this.BaseGrid.ColumnDefinitions.Count > 1)
+                {
+                    this.BaseGrid.ColumnDefinitions.RemoveRange(1, this.BaseGrid.ColumnDefinitions.Count - 1);
+                }
+
+                for (int i = 0; i < (displayList.Count - this.BaseGrid.RowDefinitions.Count); i++)
+                {
+                    var row = new RowDefinition();
+                    row.Height = GridLength.Auto;
+                    this.BaseGrid.RowDefinitions.Add(row);
                 }
             }
 

--- a/ACT.SpecialSpellTimer/SpellTimerTable.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerTable.cs
@@ -546,6 +546,7 @@
         public bool DontHide { get; set; }
         public bool HideSpellName { get; set; }
         public bool OverlapRecastTime { get; set; }
+        public bool ReduceIconBrightness { get; set; }
         public bool RegexEnabled { get; set; }
         public string JobFilter { get; set; }
         public string ZoneFilter { get; set; }

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-EN.Designer.cs
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-EN.Designer.cs
@@ -1195,6 +1195,15 @@ namespace ACT.SpecialSpellTimer.resources.strings {
         }
         
         /// <summary>
+        ///   During the recast time reduce brightness of icon に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string ReduceIconBrightnessCheckBox {
+            get {
+                return ResourceManager.GetString("ReduceIconBrightnessCheckBox", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Regular expression matching is disabled by default.\nPrefer partial string matching instead of regular expressions for better performance. に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string RegularExpressionExplanationTooltip {

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-EN.resx
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-EN.resx
@@ -893,4 +893,8 @@
     <value>Fix spell position</value>
     <comment>スペル位置を固定する</comment>
   </data>
+  <data name="ReduceIconBrightnessCheckBox" xml:space="preserve">
+    <value>During the recast time reduce brightness of icon</value>
+    <comment>リキャスト中はアイコンを暗くする</comment>
+  </data>
 </root>

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-JP.Designer.cs
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-JP.Designer.cs
@@ -1195,6 +1195,15 @@ namespace ACT.SpecialSpellTimer.resources.strings {
         }
         
         /// <summary>
+        ///   リキャスト中はアイコンを暗くする に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string ReduceIconBrightnessCheckBox {
+            get {
+                return ResourceManager.GetString("ReduceIconBrightnessCheckBox", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   正規表現が無効でも部分一致は既定で有効となっています\n正規表現OFFでの部分一致のほうがパフォーマンスは向上します に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string RegularExpressionExplanationTooltip {

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-JP.resx
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-JP.resx
@@ -893,4 +893,8 @@
     <value>スペル位置を固定する</value>
     <comment>Fix spell position</comment>
   </data>
+  <data name="ReduceIconBrightnessCheckBox" xml:space="preserve">
+    <value>リキャスト中はアイコンを暗くする</value>
+    <comment>During the recast time reduce brightness of icon</comment>
+  </data>
 </root>


### PR DESCRIPTION
下記の不具合を修正しました。

・設定されたアイコンが存在しない場合にエラーで描画が中断される
・多数のスペルが存在する場合や巨大なアイコンを設定した場合などにレイアウトが崩れる

またアイコン描画に関して下記の改良を行いました。

・タイマーをアイコンに重ねた際に、文字がアイコン内に収まるようにしました
・リキャスト中にアイコンの明度を下げるオプションを追加しました

![reduce_brightness](https://cloud.githubusercontent.com/assets/379664/9494135/4a4dacd0-4c3f-11e5-842b-6e4fb2e15c8c.png)


アイコンの明度変更は強制適用も考えたのですが、明度を変えたくない人もいるのかも？ と思ってオプションにしてあります。

ただオプションを増やし過ぎな気もしていて、もし強制適用にする（またはデフォルトは明度変更ONでオプションでOFFにする）方が良さそうであれば、そちらに変更しますので一旦リジェクトして頂ければ幸いです。
