### PR TITLE
ACT標準のSpell Timersに通知する機能を追加しました

### DIFF
--- a/ACT.SpecialSpellTimer/ConfigPanel.Designer.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.Designer.cs
@@ -199,6 +199,9 @@
             this.CombatAnalyzingLabel = new System.Windows.Forms.Label();
             this.AnalyzeCombatButton = new System.Windows.Forms.Button();
             this.OptionTabPage = new System.Windows.Forms.TabPage();
+            this.label64 = new System.Windows.Forms.Label();
+            this.EnabledNotifyNormalSpellTimerCheckBox = new System.Windows.Forms.CheckBox();
+            this.label63 = new System.Windows.Forms.Label();
             this.label49 = new System.Windows.Forms.Label();
             this.label31 = new System.Windows.Forms.Label();
             this.EnabledSpellTimerNoDecimalCheckBox = new System.Windows.Forms.CheckBox();
@@ -2149,6 +2152,9 @@
             // OptionTabPage
             // 
             this.OptionTabPage.BackColor = System.Drawing.SystemColors.Control;
+            this.OptionTabPage.Controls.Add(this.label64);
+            this.OptionTabPage.Controls.Add(this.EnabledNotifyNormalSpellTimerCheckBox);
+            this.OptionTabPage.Controls.Add(this.label63);
             this.OptionTabPage.Controls.Add(this.label49);
             this.OptionTabPage.Controls.Add(this.label31);
             this.OptionTabPage.Controls.Add(this.EnabledSpellTimerNoDecimalCheckBox);
@@ -2187,6 +2193,34 @@
             this.OptionTabPage.Size = new System.Drawing.Size(1186, 668);
             this.OptionTabPage.TabIndex = 1;
             this.OptionTabPage.Text = "OptionTabPageTitle";
+            // 
+            // label64
+            // 
+            this.label64.AutoSize = true;
+            this.label64.Location = new System.Drawing.Point(357, 358);
+            this.label64.Name = "label64";
+            this.label64.Size = new System.Drawing.Size(190, 12);
+            this.label64.TabIndex = 47;
+            this.label64.Text = "NotifyNormalSpellTimerExplainLabel";
+            // 
+            // EnabledNotifyNormalSpellTimerCheckBox
+            // 
+            this.EnabledNotifyNormalSpellTimerCheckBox.AutoSize = true;
+            this.EnabledNotifyNormalSpellTimerCheckBox.Location = new System.Drawing.Point(293, 357);
+            this.EnabledNotifyNormalSpellTimerCheckBox.Name = "EnabledNotifyNormalSpellTimerCheckBox";
+            this.EnabledNotifyNormalSpellTimerCheckBox.Size = new System.Drawing.Size(64, 16);
+            this.EnabledNotifyNormalSpellTimerCheckBox.TabIndex = 46;
+            this.EnabledNotifyNormalSpellTimerCheckBox.Text = "Enabled";
+            this.EnabledNotifyNormalSpellTimerCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // label63
+            // 
+            this.label63.AutoSize = true;
+            this.label63.Location = new System.Drawing.Point(6, 358);
+            this.label63.Name = "label63";
+            this.label63.Size = new System.Drawing.Size(153, 12);
+            this.label63.TabIndex = 45;
+            this.label63.Text = "NotifyNormalSpellTimerLabel";
             // 
             // label49
             // 
@@ -2818,5 +2852,8 @@
         private System.Windows.Forms.CheckBox HorizontalLayoutCheckBox;
         private System.Windows.Forms.CheckBox FixedPositionSpellCheckBox;
         private System.Windows.Forms.CheckBox ReduceIconBrightnessCheckBox;
+        private System.Windows.Forms.Label label64;
+        private System.Windows.Forms.CheckBox EnabledNotifyNormalSpellTimerCheckBox;
+        private System.Windows.Forms.Label label63;
     }
 }

--- a/ACT.SpecialSpellTimer/ConfigPanel.OnePointTelop.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.OnePointTelop.cs
@@ -60,6 +60,9 @@
                 {
                     source.Enabled = e1.Node.Checked;
                 }
+
+                // テロップの有効・無効が変化した際に、標準のスペルタイマーに反映する
+                SpellTimerCore.Default.applyToNormalSpellTimer();
             };
 
             this.TelopTreeView.AfterSelect += (s1, e1) =>
@@ -247,6 +250,9 @@
 
             this.TelopTreeView.Nodes.Add(node);
             this.TelopTreeView.SelectedNode = node;
+
+            // 標準のスペルタイマーへ変更を反映する
+            SpellTimerCore.Default.applyToNormalSpellTimer();
         }
 
         /// <summary>
@@ -358,6 +364,9 @@
                     this.TelopTreeView.SelectedNode = prevNode;
                 }
             }
+
+            // 標準のスペルタイマーへ変更を反映する
+            SpellTimerCore.Default.applyToNormalSpellTimer();
         }
 
         /// <summary>
@@ -383,6 +392,9 @@
 
                     this.TelopTreeView.Nodes.Add(n);
                 }
+
+                // 標準のスペルタイマーへ変更を反映する
+                SpellTimerCore.Default.applyToNormalSpellTimer();
 
                 this.TelopTreeView.ExpandAll();
             }

--- a/ACT.SpecialSpellTimer/ConfigPanel.Option.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.Option.cs
@@ -167,6 +167,10 @@
             this.RefreshIntervalNumericUpDown.Value = Settings.Default.RefreshInterval;
             this.EnabledPTPlaceholderCheckBox.Checked = Settings.Default.EnabledPartyMemberPlaceholder;
             this.EnabledSpellTimerNoDecimalCheckBox.Checked = Settings.Default.EnabledSpellTimerNoDecimal;
+            this.EnabledNotifyNormalSpellTimerCheckBox.Checked = Settings.Default.EnabledNotifyNormalSpellTimer;
+
+            // 標準のスペルタイマーへ設定を反映する
+            SpellTimerCore.Default.applyToNormalSpellTimer();
         }
 
         /// <summary>
@@ -192,6 +196,18 @@
             Settings.Default.RefreshInterval = (long)this.RefreshIntervalNumericUpDown.Value;
             Settings.Default.EnabledPartyMemberPlaceholder = this.EnabledPTPlaceholderCheckBox.Checked;
             Settings.Default.EnabledSpellTimerNoDecimal = this.EnabledSpellTimerNoDecimalCheckBox.Checked;
+
+            // 有効状態から無効状態に変化する場合は、標準のスペルタイマーから設定を削除する
+            if (Settings.Default.EnabledNotifyNormalSpellTimer &&
+                !this.EnabledNotifyNormalSpellTimerCheckBox.Checked)
+            {
+                SpellTimerCore.Default.clearNormalSpellTimer(true);
+            }
+
+            Settings.Default.EnabledNotifyNormalSpellTimer = this.EnabledNotifyNormalSpellTimerCheckBox.Checked;
+
+            // 標準のスペルタイマーへ設定を反映する
+            SpellTimerCore.Default.applyToNormalSpellTimer();
 
             // 設定を保存する
             Settings.Default.Save();

--- a/ACT.SpecialSpellTimer/ConfigPanel.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.cs
@@ -149,6 +149,9 @@
                         node.Checked = e1.Node.Checked;
                     }
                 }
+
+                // スペルの有効・無効が変化した際に、標準のスペルタイマーに反映するさせる
+                SpellTimerCore.Default.applyToNormalSpellTimer();
             };
 
             this.SelectJobButton.Click += (s1, e1) =>
@@ -338,6 +341,9 @@
                     this.SpellTimerTreeView.SelectedNode = node;
                 }
             }
+
+            // 標準のスペルタイマーへ変更を反映する
+            SpellTimerCore.Default.applyToNormalSpellTimer();
         }
 
         /// <summary>
@@ -500,6 +506,9 @@
                     targetNode.Parent.Remove();
                 }
             }
+
+            // 標準のスペルタイマーへ変更を反映する
+            SpellTimerCore.Default.applyToNormalSpellTimer();
         }
 
         /// <summary>
@@ -629,6 +638,9 @@
 
                     this.SpellTimerTreeView.Nodes.Add(n);
                 }
+
+                // 標準のスペルタイマーへ変更を反映する
+                SpellTimerCore.Default.applyToNormalSpellTimer();
 
                 this.SpellTimerTreeView.ExpandAll();
             }

--- a/ACT.SpecialSpellTimer/ConfigPanel.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.cs
@@ -150,7 +150,7 @@
                     }
                 }
 
-                // スペルの有効・無効が変化した際に、標準のスペルタイマーに反映するさせる
+                // スペルの有効・無効が変化した際に、標準のスペルタイマーに反映する
                 SpellTimerCore.Default.applyToNormalSpellTimer();
             };
 

--- a/ACT.SpecialSpellTimer/OnePointTelopController.cs
+++ b/ACT.SpecialSpellTimer/OnePointTelopController.cs
@@ -198,6 +198,7 @@
             {
                 var regex = telop.Regex;
                 var regexToHide = telop.RegexToHide;
+                var notifyNeeded = false;
 
                 foreach (var log in logLines)
                 {
@@ -229,6 +230,7 @@
                                 SoundController.Default.Play(telop.MatchSound);
                                 SoundController.Default.Play(telop.MatchTextToSpeak);
 
+                                notifyNeeded = true;
                                 continue;
                             }
                         }
@@ -263,6 +265,7 @@
                                 SoundController.Default.Play(tts);
                             }
 
+                            notifyNeeded = true;
                             continue;
                         }
                     }
@@ -277,6 +280,7 @@
                                 keyword.ToUpper()))
                             {
                                 telop.ForceHide = true;
+                                notifyNeeded = true;
                                 continue;
                             }
                         }
@@ -288,6 +292,7 @@
                         if (regexToHide.IsMatch(log))
                         {
                             telop.ForceHide = true;
+                            notifyNeeded = true;
                             continue;
                         }
                     }
@@ -308,6 +313,12 @@
                             telop.DelayTextToSpeak;
                         SoundController.Default.Play(tts);
                     }
+                }
+
+                if (notifyNeeded)
+                {
+                    SpellTimerCore.Default.updateNormalSpellTimerForTelop(telop, telop.ForceHide);
+                    SpellTimerCore.Default.notifyNormalSpellTimerForTelop(telop.Title);
                 }
             }); // end loop telops
         }

--- a/ACT.SpecialSpellTimer/Properties/Settings.Designer.cs
+++ b/ACT.SpecialSpellTimer/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace ACT.SpecialSpellTimer.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "12.0.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -296,6 +296,30 @@ namespace ACT.SpecialSpellTimer.Properties {
             }
             set {
                 this["EnabledSpellTimerNoDecimal"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool EnabledNotifyNormalSpellTimer {
+            get {
+                return ((bool)(this["EnabledNotifyNormalSpellTimer"]));
+            }
+            set {
+                this["EnabledNotifyNormalSpellTimer"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("spespe_")]
+        public string NotifyNormalSpellTimerPrefix {
+            get {
+                return ((string)(this["NotifyNormalSpellTimerPrefix"]));
+            }
+            set {
+                this["NotifyNormalSpellTimerPrefix"] = value;
             }
         }
     }

--- a/ACT.SpecialSpellTimer/Properties/Settings.settings
+++ b/ACT.SpecialSpellTimer/Properties/Settings.settings
@@ -71,5 +71,11 @@
     <Setting Name="EnabledSpellTimerNoDecimal" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="EnabledNotifyNormalSpellTimer" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="NotifyNormalSpellTimerPrefix" Type="System.String" Scope="User">
+      <Value Profile="(Default)">spespe_</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/ACT.SpecialSpellTimer/SpellTimerCore.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerCore.cs
@@ -360,6 +360,7 @@
             Parallel.ForEach(spells, (spell) =>
             {
                 var regex = spell.Regex;
+                var notifyNeeded = false;
 
                 // マッチする？
                 foreach (var logLine in logLines)
@@ -391,6 +392,8 @@
                             // マッチ時点のサウンドを再生する
                             this.Play(spell.MatchSound);
                             this.Play(spell.MatchTextToSpeak);
+
+                            notifyNeeded = true;
                         }
                     }
                     else
@@ -419,6 +422,8 @@
                                 var tts = match.Result(spell.MatchTextToSpeak);
                                 this.Play(tts);
                             }
+
+                            notifyNeeded = true;
                         }
                     }
 
@@ -486,11 +491,20 @@
 
                             spell.MatchDateTime = now;
                             spell.CompleteScheduledTime = newSchedule;
+
+                            notifyNeeded = true;
                         }
                     }
                     // end if 延長マッチング
                 }
                 // end foreach マッチング
+
+                // ACT標準のSpellTimerに変更を通知する
+                if (notifyNeeded)
+                {
+                    updateNormalSpellTimer(spell, false);
+                    notifyNormalSpellTimer(spell);
+                }
 
                 // Repeat対象のSpellを更新する
                 if (spell.RepeatEnabled &&
@@ -842,6 +856,105 @@
             }
             
             return null;
+        }
+
+        /// <summary>
+        /// 有効なSpellTimerをACT標準のSpellTimerに設定を反映させる
+        /// </summary>
+        public void applyToNormalSpellTimer()
+        {
+            // 標準スペルタイマーへの通知が無効であれば何もしない
+            if (!Settings.Default.EnabledNotifyNormalSpellTimer)
+            {
+                return;
+            }
+
+            // 設定を一旦すべて削除する
+            clearNormalSpellTimer();
+
+            var spells = SpellTimerTable.Table.Where(x => x.Enabled);
+            foreach (var spell in spells)
+            {
+                updateNormalSpellTimer(spell, true);
+            }
+
+            // ACTのスペルタイマーに変更を反映する
+            Advanced_Combat_Tracker.ActGlobals.oFormSpellTimers.RebuildSpellTreeView();
+        }
+
+        /// <summary>
+        /// ACT標準のスペルタイマーの設定を追加・更新する
+        /// </summary>
+        /// <param name="spellTimer">元になるスペルタイマー</param>
+        /// <param name="useRecastTime">リキャスト時間にRecastの値を使うか。falseの場合はCompleteScheduledTimeから計算される</param>
+        public void updateNormalSpellTimer(SpellTimer spellTimer, bool useRecastTime)
+        {
+            if (!Settings.Default.EnabledNotifyNormalSpellTimer)
+            {
+                return;
+            }
+
+            var prefix = Settings.Default.NotifyNormalSpellTimerPrefix;
+            var spellName = prefix + "spell_" + spellTimer.SpellTitle;
+            var categoryName = prefix + spellTimer.Panel;
+            var recastTime = useRecastTime ? spellTimer.RecastTime : (spellTimer.CompleteScheduledTime - DateTime.Now).TotalSeconds;
+
+            var timerData = new Advanced_Combat_Tracker.TimerData(spellName, categoryName);
+            timerData.TimerValue = (int)recastTime;
+            timerData.RemoveValue = (int)-Settings.Default.TimeOfHideSpell;
+            timerData.WarningValue = 0;
+            timerData.OnlyMasterTicks = true;
+
+            timerData.Panel1Display = false;
+            timerData.Panel2Display = false;
+
+            timerData.WarningSoundData = "none"; // disable warning sound
+
+            // initialize other parameters
+            timerData.RestrictToMe = false;
+            timerData.AbsoluteTiming = false;
+            timerData.RestrictToCategory = false;
+
+            Advanced_Combat_Tracker.ActGlobals.oFormSpellTimers.AddEditTimerDef(timerData);
+        }
+
+        /// <summary>
+        /// ACT標準のスペルタイマーに通知する
+        /// </summary>
+        /// <param name="spellTimer">通知先に対応するスペルタイマー</param>
+        public void notifyNormalSpellTimer(SpellTimer spellTimer)
+        {
+            if (!Settings.Default.EnabledNotifyNormalSpellTimer)
+            {
+                return;
+            }
+
+            var prefix = Settings.Default.NotifyNormalSpellTimerPrefix;
+            var spellName = prefix + "spell_" + spellTimer.SpellTitle;
+            Advanced_Combat_Tracker.ActGlobals.oFormSpellTimers.NotifySpell("attacker", spellName, false, "victim", false);
+        }
+
+        /// <summary>
+        /// ACT標準のスペルタイマーから設定を削除する
+        /// </summary>
+        /// <param name="immediate">変更を即時に反映させるか？</param>
+        public void clearNormalSpellTimer(bool immediate=false)
+        {
+            var prefix = Settings.Default.NotifyNormalSpellTimerPrefix;
+            var timerDefs = Advanced_Combat_Tracker.ActGlobals.oFormSpellTimers.TimerDefs
+                .Where(p => p.Key.StartsWith(prefix))
+                .Select(x => x.Value)
+                .ToList();
+            foreach (var timerDef in timerDefs)
+            {
+                Advanced_Combat_Tracker.ActGlobals.oFormSpellTimers.RemoveTimerDef(timerDef);
+            }
+
+            // ACTのスペルタイマーに変更を反映する
+            if (immediate)
+            {
+                Advanced_Combat_Tracker.ActGlobals.oFormSpellTimers.RebuildSpellTreeView();
+            }
         }
 
         /// <summary>

--- a/ACT.SpecialSpellTimer/SpellTimerCore.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerCore.cs
@@ -878,6 +878,12 @@
                 updateNormalSpellTimer(spell, true);
             }
 
+            var telops = OnePointTelopTable.Default.Table.Where(x => x.Enabled);
+            foreach (var telop  in telops)
+            {
+                updateNormalSpellTimerForTelop(telop, false);
+            }
+
             // ACTのスペルタイマーに変更を反映する
             Advanced_Combat_Tracker.ActGlobals.oFormSpellTimers.RebuildSpellTreeView();
         }
@@ -904,6 +910,43 @@
             timerData.RemoveValue = (int)-Settings.Default.TimeOfHideSpell;
             timerData.WarningValue = 0;
             timerData.OnlyMasterTicks = true;
+            timerData.Tooltip = spellTimer.SpellTitleReplaced;
+
+            timerData.Panel1Display = false;
+            timerData.Panel2Display = false;
+
+            timerData.WarningSoundData = "none"; // disable warning sound
+
+            // initialize other parameters
+            timerData.RestrictToMe = false;
+            timerData.AbsoluteTiming = false;
+            timerData.RestrictToCategory = false;
+
+            Advanced_Combat_Tracker.ActGlobals.oFormSpellTimers.AddEditTimerDef(timerData);
+        }
+
+        /// <summary>
+        /// ACT標準のスペルタイマーの設定を追加・更新する（テロップ用）
+        /// </summary>
+        /// <param name="spellTimer">元になるテロップ</param>
+        /// <param name="forceHide">強制非表示か？</param>
+        public void updateNormalSpellTimerForTelop(OnePointTelop telop, bool forceHide)
+        {
+            if (!Settings.Default.EnabledNotifyNormalSpellTimer)
+            {
+                return;
+            }
+
+            var prefix = Settings.Default.NotifyNormalSpellTimerPrefix;
+            var spellName = prefix + "telop_" + telop.Title;
+            var categoryName = prefix + "telops";
+
+            var timerData = new Advanced_Combat_Tracker.TimerData(spellName, categoryName);
+            timerData.TimerValue = forceHide ? 1 : (int)(telop.DisplayTime + telop.Delay);
+            timerData.RemoveValue = forceHide ? -timerData.TimerValue : 0;
+            timerData.WarningValue = (int)telop.DisplayTime;
+            timerData.OnlyMasterTicks = telop.AddMessageEnabled ? false : true;
+            timerData.Tooltip = telop.MessageReplaced;
 
             timerData.Panel1Display = false;
             timerData.Panel2Display = false;
@@ -931,6 +974,22 @@
 
             var prefix = Settings.Default.NotifyNormalSpellTimerPrefix;
             var spellName = prefix + "spell_" + spellTimer.SpellTitle;
+            Advanced_Combat_Tracker.ActGlobals.oFormSpellTimers.NotifySpell("attacker", spellName, false, "victim", false);
+        }
+
+        /// <summary>
+        /// ACT標準のスペルタイマーに通知する（テロップ用）
+        /// </summary>
+        /// <param name="telopTitle">通知先に対応するテロップ名</param>
+        public void notifyNormalSpellTimerForTelop(string telopTitle)
+        {
+            if (!Settings.Default.EnabledNotifyNormalSpellTimer)
+            {
+                return;
+            }
+
+            var prefix = Settings.Default.NotifyNormalSpellTimerPrefix;
+            var spellName = prefix + "telop_" + telopTitle;
             Advanced_Combat_Tracker.ActGlobals.oFormSpellTimers.NotifySpell("attacker", spellName, false, "victim", false);
         }
 

--- a/ACT.SpecialSpellTimer/app.config
+++ b/ACT.SpecialSpellTimer/app.config
@@ -76,6 +76,12 @@
       <setting name="EnabledSpellTimerNoDecimal" serializeAs="String">
         <value>False</value>
       </setting>
+      <setting name="EnabledNotifyNormalSpellTimer" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="NotifyNormalSpellTimerPrefix" serializeAs="String">
+        <value>spespe_</value>
+      </setting>
     </ACT.SpecialSpellTimer.Properties.Settings>
   </userSettings>
   <startup>

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-EN.Designer.cs
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-EN.Designer.cs
@@ -988,6 +988,24 @@ namespace ACT.SpecialSpellTimer.resources.strings {
         }
         
         /// <summary>
+        ///   ※ Notify ACT&apos;s SpellTimer when log matched. (Experimental) に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string NotifyNormalSpellTimerExplainLabel {
+            get {
+                return ResourceManager.GetString("NotifyNormalSpellTimerExplainLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Notify ACT&apos;s SpellTimer に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string NotifyNormalSpellTimerLabel {
+            get {
+                return ResourceManager.GetString("NotifyNormalSpellTimerLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   No に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string NumberHeader {

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-EN.resx
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-EN.resx
@@ -897,4 +897,12 @@
     <value>During the recast time reduce brightness of icon</value>
     <comment>リキャスト中はアイコンを暗くする</comment>
   </data>
+  <data name="NotifyNormalSpellTimerExplainLabel" xml:space="preserve">
+    <value>※ Notify ACT's SpellTimer when log matched. (Experimental)</value>
+    <comment>※ログマッチ時に標準のスペルタイマーへの通知が行われます（試験的な機能）</comment>
+  </data>
+  <data name="NotifyNormalSpellTimerLabel" xml:space="preserve">
+    <value>Notify ACT's SpellTimer</value>
+    <comment>標準のスペルタイマーに通知する</comment>
+  </data>
 </root>

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-JP.Designer.cs
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-JP.Designer.cs
@@ -988,6 +988,24 @@ namespace ACT.SpecialSpellTimer.resources.strings {
         }
         
         /// <summary>
+        ///   ※ログマッチ時に標準のスペルタイマーへの通知が行われます（試験的な機能） に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string NotifyNormalSpellTimerExplainLabel {
+            get {
+                return ResourceManager.GetString("NotifyNormalSpellTimerExplainLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   標準のスペルタイマーに通知する に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string NotifyNormalSpellTimerLabel {
+            get {
+                return ResourceManager.GetString("NotifyNormalSpellTimerLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   No に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string NumberHeader {

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-JP.resx
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-JP.resx
@@ -897,4 +897,12 @@
     <value>リキャスト中はアイコンを暗くする</value>
     <comment>During the recast time reduce brightness of icon</comment>
   </data>
+  <data name="NotifyNormalSpellTimerExplainLabel" xml:space="preserve">
+    <value>※ログマッチ時に標準のスペルタイマーへの通知が行われます（試験的な機能）</value>
+    <comment>※ Notify ACT's SpellTimer when log matched. (Experimental)</comment>
+  </data>
+  <data name="NotifyNormalSpellTimerLabel" xml:space="preserve">
+    <value>標準のスペルタイマーに通知する</value>
+    <comment>Notify ACT's SpellTimer</comment>
+  </data>
 </root>


### PR DESCRIPTION
ログマッチ（リキャスト開始・延長、テロップ表示・非表示）時に、ACT標準のSpell Timersに通知できるようにしました。

下記のオプションにより有効・無効の切り替えを可能にしています。

![notify_option](https://cloud.githubusercontent.com/assets/379664/9734511/8f5da15c-566e-11e5-9656-a3aecce5e30f.png)

有効にすると、スペルタイマー及びテロップの設定が”spespe_”というプレフィックス付きで、ACT標準のSpell Timersにコピーされます。またログマッチ時には、このコピーされたスペルが開始したことが、ACT標準のSpell TImersに通知されます。
（無効にするとSpell Timers内の”spespe_”で始まるスペルは全て削除されます）

これにより、SpecialSpellTimerでマッチした内容を、別プラグイン（OverlayPluginを想定）でも表示できるようになります。

![notify_act](https://cloud.githubusercontent.com/assets/379664/9734517/994dfea0-566e-11e5-97ba-c2992dbc4f40.png)
