### PR TITLE
アイコン表示に関する微修正を行いました

### DIFF
--- a/ACT.SpecialSpellTimer/ConfigPanel.Option.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.Option.cs
@@ -197,6 +197,9 @@
             Settings.Default.EnabledPartyMemberPlaceholder = this.EnabledPTPlaceholderCheckBox.Checked;
             Settings.Default.EnabledSpellTimerNoDecimal = this.EnabledSpellTimerNoDecimalCheckBox.Checked;
 
+            Settings.Default.ReadyText = Settings.Default.ReadyText;
+            Settings.Default.OverText = Settings.Default.OverText;
+
             // 有効状態から無効状態に変化する場合は、標準のスペルタイマーから設定を削除する
             if (Settings.Default.EnabledNotifyNormalSpellTimer &&
                 !this.EnabledNotifyNormalSpellTimerCheckBox.Checked)

--- a/ACT.SpecialSpellTimer/Properties/Settings.Designer.cs
+++ b/ACT.SpecialSpellTimer/Properties/Settings.Designer.cs
@@ -322,5 +322,29 @@ namespace ACT.SpecialSpellTimer.Properties {
                 this["NotifyNormalSpellTimerPrefix"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("Ready")]
+        public string ReadyText {
+            get {
+                return ((string)(this["ReadyText"]));
+            }
+            set {
+                this["ReadyText"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("Over")]
+        public string OverText {
+            get {
+                return ((string)(this["OverText"]));
+            }
+            set {
+                this["OverText"] = value;
+            }
+        }
     }
 }

--- a/ACT.SpecialSpellTimer/Properties/Settings.settings
+++ b/ACT.SpecialSpellTimer/Properties/Settings.settings
@@ -77,5 +77,11 @@
     <Setting Name="NotifyNormalSpellTimerPrefix" Type="System.String" Scope="User">
       <Value Profile="(Default)">spespe_</Value>
     </Setting>
+    <Setting Name="ReadyText" Type="System.String" Scope="User">
+      <Value Profile="(Default)">Ready</Value>
+    </Setting>
+    <Setting Name="OverText" Type="System.String" Scope="User">
+      <Value Profile="(Default)">Over</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/ACT.SpecialSpellTimer/SpellTimerControl.xaml.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerControl.xaml.cs
@@ -212,7 +212,7 @@
             tb = this.RecastTimeTextBlock;
             var recast = this.RecastTime > 0 ?
                 this.RecastTime.ToString(recastTimeFormat) :
-                this.IsReverse ? "Over" : "Ready";
+                this.IsReverse ? Settings.Default.OverText : Settings.Default.ReadyText;
             if (tb.Text != recast)
             {
                 tb.Text = recast;

--- a/ACT.SpecialSpellTimer/SpellTimerControl.xaml.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerControl.xaml.cs
@@ -190,11 +190,11 @@
             {
                 if (this.RecastTime > 0)
                 {
-                    image.Opacity = this.IsReverse ? 1.0 : 0.6;
+                    image.Opacity = this.IsReverse ? 1.0 : 0.55;
                 }
                 else
                 {
-                    image.Opacity = this.IsReverse ? 0.6 : 1.0;
+                    image.Opacity = this.IsReverse ? 0.55 : 1.0;
                 }
             }
             else

--- a/ACT.SpecialSpellTimer/SpellTimerControl.xaml.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerControl.xaml.cs
@@ -98,6 +98,17 @@
         public int BarHeight { get; set; }
 
         /// <summary>
+        /// スペル表示領域の幅
+        /// </summary>
+        public int SpellWidth
+        {
+            get
+            {
+                return BarWidth > SpellIconSize ? BarWidth : SpellIconSize;
+            }
+        }
+
+        /// <summary>
         /// フォント
         /// </summary>
         public FontInfo FontInfo { get; set; }
@@ -135,7 +146,7 @@
 #if false
             var sw = Stopwatch.StartNew();
 #endif
-            this.Width = this.BarWidth;
+            this.Width = this.SpellWidth;
 
             // Brushを生成する
             var fontColor = string.IsNullOrWhiteSpace(this.FontColor) ?

--- a/ACT.SpecialSpellTimer/VisualSettingControl.cs
+++ b/ACT.SpecialSpellTimer/VisualSettingControl.cs
@@ -406,6 +406,9 @@
                 (this.SamplePictureBox.Width / 2) - (barSize.Width / 2),
                 this.SamplePictureBox.Height - barSize.Height - 12);
 
+            var spellWidth = barSize.Width > this.SpellIconSize ? barSize.Width : this.SpellIconSize;
+            var spellX = barSize.Width > this.SpellIconSize ? barLocation.X : (this.SamplePictureBox.Size.Width / 2) - (this.SpellIconSize / 2);
+
             var bmp = new Bitmap(this.SamplePictureBox.Width, this.SamplePictureBox.Height);
             using (var g = Graphics.FromImage(bmp))
             {
@@ -450,7 +453,7 @@
                         var image = System.Drawing.Image.FromFile(spellIcon.FullPath);
                         g.DrawImage(
                             image,
-                            barLocation.X,
+                            spellX,
                             barLocation.Y - this.SpellIconSize,
                             (float)this.SpellIconSize,
                             (float)this.SpellIconSize);
@@ -463,9 +466,9 @@
                 var fontOutlinePen = new Pen(fontOutlineColor, 0.2f);
                 var fontHeight = font.Size * 2; // 正しくない計算
                 var fontRect = new Rectangle(
-                    hasIcon ? barLocation.X + this.SpellIconSize : barLocation.X,
+                    hasIcon ? spellX + this.SpellIconSize : spellX,
                     barLocation.Y - 2 - (int)fontHeight,
-                    hasIcon ? barSize.Width - this.SpellIconSize : barSize.Width,
+                    hasIcon ? spellWidth - this.SpellIconSize : spellWidth,
                     barLocation.Y - 2);
 
                 if (!this.BarEnabled)
@@ -510,11 +513,13 @@
 
                     if (this.OverlapRecastTime)
                     {
-                        fontRect.X = barLocation.X;
+                        fontRect.X = spellX;
+                        fontRect.Width = this.SpellIconSize;
+                        recastSf.Alignment = StringAlignment.Center;
                     }
 
                     path.AddString(
-                        "120.0",
+                        Settings.Default.EnabledSpellTimerNoDecimal ? "120" : "120.0",
                         font.FontFamily,
                         (int)font.Style,
                         (float)font.ToFontSizeWPF(),

--- a/ACT.SpecialSpellTimer/app.config
+++ b/ACT.SpecialSpellTimer/app.config
@@ -82,6 +82,12 @@
       <setting name="NotifyNormalSpellTimerPrefix" serializeAs="String">
         <value>spespe_</value>
       </setting>
+      <setting name="ReadyText" serializeAs="String">
+        <value>Ready</value>
+      </setting>
+      <setting name="OverText" serializeAs="String">
+        <value>Over</value>
+      </setting>
     </ACT.SpecialSpellTimer.Properties.Settings>
   </userSettings>
   <startup>


### PR DESCRIPTION
アイコン表示に関する微修正を行いました

* バーの幅がアイコンより小さい場合でも、アイコンが欠けずに表示されるようにしました。
* 「明度を下げる」有効時に、アイコンが以前より少しだけ暗くなるようにしました。
* 設定画面にあるプレビューの再現度を向上しました。
* Ready / Overの文字列を設定ファイルから読み込むようにしました。（設定UIは未実装※）

※オプション画面で「適用する」と、設定ファイル内にプロパティが作成されます。
その後、直接ファイルを編集することで、Ready / Overの文字列を変更することが可能です。

設定ファイル： $USER/AppData/Local/EQAditu/…/user.config
プロパティ： ReadyText 及び OverText
