### PR TITLE
リキャストの開始時刻をACTから通知されるログ検出時間に変更しました

### DIFF
--- a/ACT.SpecialSpellTimer/LogBuffer.cs
+++ b/ACT.SpecialSpellTimer/LogBuffer.cs
@@ -48,7 +48,7 @@
         /// <summary>
         /// 内部バッファ
         /// </summary>
-        private List<string> buffer = new List<string>();
+        private List<LogLine> buffer = new List<LogLine>();
 
         /// <summary>
         /// コンストラクタ
@@ -74,7 +74,7 @@
         /// </summary>
         /// <returns>
         /// ログ行の配列</returns>
-        public string[] GetLogLines()
+        public LogLine[] GetLogLines()
         {
             lock (this.buffer)
             {
@@ -119,8 +119,8 @@
 #if false
             Debug.WriteLine(logInfo.logLine);
 #endif
-
-            var logLine = logInfo.logLine.Trim();
+            var logLineObject = new LogLine(logInfo.logLine.Trim(), logInfo.detectedTime);
+            var logLine = logLineObject.Text;
 
             // ジョブに変化あり？
             if (logLine.Contains("にチェンジした。") ||
@@ -207,7 +207,7 @@
 
             lock (this.buffer)
             {
-                this.buffer.Add(logLine);
+                this.buffer.Add(logLineObject);
             }
         }
 
@@ -435,6 +435,18 @@
                     SpellTimerTable.ClearReplacedKeywords();
                     OnePointTelopTable.Default.ClearReplacedKeywords();
                 }
+            }
+        }
+
+        public struct LogLine
+        {
+            public String Text;
+            public DateTime DetectedTime;
+
+            public LogLine(String text, DateTime detectedTime)
+            {
+                this.Text = text;
+                this.DetectedTime = detectedTime;
             }
         }
     }

--- a/ACT.SpecialSpellTimer/OnePointTelopController.cs
+++ b/ACT.SpecialSpellTimer/OnePointTelopController.cs
@@ -192,7 +192,7 @@
         /// <param name="logLines">ログ行</param>
         public static void Match(
             OnePointTelop[] telops,
-            string[] logLines)
+            LogBuffer.LogLine[] logLines)
         {
             Parallel.ForEach(telops, (telop) =>
             {
@@ -208,7 +208,7 @@
                         var keyword = telop.KeywordReplaced;
                         if (!string.IsNullOrWhiteSpace(keyword))
                         {
-                            if (log.ToUpper().Contains(
+                            if (log.Text.ToUpper().Contains(
                                 keyword.ToUpper()))
                             {
                                 if (!telop.AddMessageEnabled)
@@ -222,9 +222,9 @@
                                         Environment.NewLine + telop.Message;
                                 }
 
-                                telop.MatchDateTime = DateTime.Now;
+                                telop.MatchDateTime = log.DetectedTime;
                                 telop.Delayed = false;
-                                telop.MatchedLog = log;
+                                telop.MatchedLog = log.Text;
                                 telop.ForceHide = false;
 
                                 SoundController.Default.Play(telop.MatchSound);
@@ -239,7 +239,7 @@
                     // 正規表現マッチ
                     if (regex != null)
                     {
-                        var match = regex.Match(log);
+                        var match = regex.Match(log.Text);
                         if (match.Success)
                         {
                             if (!telop.AddMessageEnabled)
@@ -253,9 +253,9 @@
                                     Environment.NewLine + match.Result(telop.Message);
                             }
 
-                            telop.MatchDateTime = DateTime.Now;
+                            telop.MatchDateTime = log.DetectedTime;
                             telop.Delayed = false;
-                            telop.MatchedLog = log;
+                            telop.MatchedLog = log.Text;
                             telop.ForceHide = false;
 
                             SoundController.Default.Play(telop.MatchSound);
@@ -276,7 +276,7 @@
                         var keyword = telop.KeywordToHideReplaced;
                         if (!string.IsNullOrWhiteSpace(keyword))
                         {
-                            if (log.ToUpper().Contains(
+                            if (log.Text.ToUpper().Contains(
                                 keyword.ToUpper()))
                             {
                                 telop.ForceHide = true;
@@ -289,7 +289,7 @@
                     // 正規表現マッチ(強制非表示)
                     if (regexToHide != null)
                     {
-                        if (regexToHide.IsMatch(log))
+                        if (regexToHide.IsMatch(log.Text))
                         {
                             telop.ForceHide = true;
                             notifyNeeded = true;

--- a/ACT.SpecialSpellTimer/SpellTimerCore.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerCore.cs
@@ -380,7 +380,7 @@
         /// <param name="logLines">ログ</param>
         private void MatchSpells(
             SpellTimer[] spells,
-            string[] logLines)
+            LogBuffer.LogLine[] logLines)
         {
             Parallel.ForEach(spells, (spell) =>
             {
@@ -401,14 +401,14 @@
                         }
 
                         // キーワードが含まれるか？
-                        if (logLine.ToUpper().Contains(
+                        if (logLine.Text.ToUpper().Contains(
                             keyword.ToUpper()))
                         {
                             // ヒットしたログを格納する
-                            spell.MatchedLog = logLine;
+                            spell.MatchedLog = logLine.Text;
 
                             spell.SpellTitleReplaced = spell.SpellTitle;
-                            spell.MatchDateTime = DateTime.Now;
+                            spell.MatchDateTime = logLine.DetectedTime;
                             spell.OverDone = false;
                             spell.BeforeDone = false;
                             spell.TimeupDone = false;
@@ -424,16 +424,16 @@
                     else
                     {
                         // 正規表現でマッチングする
-                        var match = regex.Match(logLine);
+                        var match = regex.Match(logLine.Text);
                         if (match.Success)
                         {
                             // ヒットしたログを格納する
-                            spell.MatchedLog = logLine;
+                            spell.MatchedLog = logLine.Text;
 
                             // 置換したスペル名を格納する
                             spell.SpellTitleReplaced = match.Result(spell.SpellTitle);
 
-                            spell.MatchDateTime = DateTime.Now;
+                            spell.MatchDateTime = logLine.DetectedTime;
                             spell.OverDone = false;
                             spell.BeforeDone = false;
                             spell.TimeupDone = false;
@@ -473,12 +473,12 @@
                             {
                                 if (!string.IsNullOrWhiteSpace(keywordToExtend))
                                 {
-                                    match = logLine.ToUpper().Contains(keywordToExtend.ToUpper());
+                                    match = logLine.Text.ToUpper().Contains(keywordToExtend.ToUpper());
                                 }
                             }
                             else
                             {
-                                match = regexToExtend.Match(logLine).Success;
+                                match = regexToExtend.Match(logLine.Text).Success;
                             }
 
                             if (!match)
@@ -486,7 +486,7 @@
                                 continue;
                             }
 
-                            var now = DateTime.Now;
+                            var now = logLine.DetectedTime;
 
                             // リキャストタイムを延長する
                             var newSchedule = spell.CompleteScheduledTime.AddSeconds(timeToExtend);

--- a/ACT.SpecialSpellTimer/TextCommandController.cs
+++ b/ACT.SpecialSpellTimer/TextCommandController.cs
@@ -24,18 +24,18 @@
         /// <param name="logLines">
         /// ログ行</param>
         public static void MatchCommand(
-            string[] logLines)
+            LogBuffer.LogLine[] logLines)
         {
             var commandDone = false;
             foreach (var log in logLines)
             {
                 // 正規表現の前にキーワードがなければ抜けてしまう
-                if (!log.ToLower().Contains("/spespe"))
+                if (!log.Text.ToLower().Contains("/spespe"))
                 {
                     continue;
                 }
 
-                var match = regexCommand.Match(log);
+                var match = regexCommand.Match(log.Text);
                 if (!match.Success)
                 {
                     continue;


### PR DESCRIPTION
リキャストの開始時刻として、処理時点の時刻ではなく、ACTから通知されるログ検出時間（確認した限りではACTのログ表示で左端に表示される時間と同じ値）を利用するようにしました。

これにより、リキャストの計算が処理タイミング（「画面の更新間隔」の設定値など）の影響を受けなくなります。またリキャスト時間の計算がより正確になることも期待できます。
