### PR TITLE
スペルタイマーのバー表示を改良しました

### DIFF
--- a/ACT.SpecialSpellTimer/ConfigPanel.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.cs
@@ -135,6 +135,7 @@
                 if (source != null)
                 {
                     source.Enabled = e1.Node.Checked;
+                    source.UpdateDone = false;
                 }
                 else
                 {
@@ -299,6 +300,7 @@
                 }
 
                 nr.MatchDateTime = DateTime.MinValue;
+                nr.UpdateDone = false;
                 nr.Enabled = true;
                 nr.DisplayNo = SpellTimerTable.Table.Any() ?
                     SpellTimerTable.Table.Max(x => x.DisplayNo) + 1 :
@@ -637,6 +639,12 @@
                     n.Checked = children.Any(x => x.Checked);
 
                     this.SpellTimerTreeView.Nodes.Add(n);
+
+                    // バー表示の初期化が必要なことを記録
+                    foreach (var spell in spells)
+                    {
+                        spell.UpdateDone = false;
+                    }
                 }
 
                 // 標準のスペルタイマーへ変更を反映する

--- a/ACT.SpecialSpellTimer/Properties/Settings.Designer.cs
+++ b/ACT.SpecialSpellTimer/Properties/Settings.Designer.cs
@@ -346,5 +346,17 @@ namespace ACT.SpecialSpellTimer.Properties {
                 this["OverText"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("15")]
+        public int MaxFPS {
+            get {
+                return ((int)(this["MaxFPS"]));
+            }
+            set {
+                this["MaxFPS"] = value;
+            }
+        }
     }
 }

--- a/ACT.SpecialSpellTimer/Properties/Settings.settings
+++ b/ACT.SpecialSpellTimer/Properties/Settings.settings
@@ -83,5 +83,8 @@
     <Setting Name="OverText" Type="System.String" Scope="User">
       <Value Profile="(Default)">Over</Value>
     </Setting>
+    <Setting Name="MaxFPS" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">15</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/ACT.SpecialSpellTimer/SpellTimerControl.xaml
+++ b/ACT.SpecialSpellTimer/SpellTimerControl.xaml
@@ -33,16 +33,23 @@
       VerticalAlignment="Top" 
       >
       <Rectangle x:Name="BarBackRectangle" />
-      <Rectangle x:Name="BarRectangle" >
-        <Rectangle.Effect>
+      <Canvas>
+        <Canvas.Effect>
           <DropShadowEffect
             x:Name="BarEffect"
             ShadowDepth="0"
             BlurRadius="11"
             RenderingBias="Performance"
-            />
-        </Rectangle.Effect>
-      </Rectangle>
+          />
+        </Canvas.Effect>
+        <Canvas x:Name="BarCanvas">
+          <Canvas.RenderTransform>
+            <ScaleTransform x:Name="BarScale" ScaleX="0.0" ScaleY="1.0" CenterX="1.0" />
+          </Canvas.RenderTransform>
+          <Rectangle x:Name="BarRectangle">
+          </Rectangle>
+        </Canvas>
+      </Canvas>
       <Rectangle x:Name="BarOutlineRectangle" />
     </Canvas>
 

--- a/ACT.SpecialSpellTimer/SpellTimerCore.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerCore.cs
@@ -389,6 +389,7 @@
 
                             spell.SpellTitleReplaced = spell.SpellTitle;
                             spell.MatchDateTime = DateTime.Now;
+                            spell.UpdateDone = false;
                             spell.OverDone = false;
                             spell.BeforeDone = false;
                             spell.TimeupDone = false;
@@ -414,6 +415,7 @@
                             spell.SpellTitleReplaced = match.Result(spell.SpellTitle);
 
                             spell.MatchDateTime = DateTime.Now;
+                            spell.UpdateDone = false;
                             spell.OverDone = false;
                             spell.BeforeDone = false;
                             spell.TimeupDone = false;
@@ -471,6 +473,7 @@
                             // リキャストタイムを延長する
                             var newSchedule = spell.CompleteScheduledTime.AddSeconds(timeToExtend);
                             spell.BeforeDone = false;
+                            spell.UpdateDone = false;
 
                             if (spell.ExtendBeyondOriginalRecastTime)
                             {
@@ -518,6 +521,7 @@
                     if (DateTime.Now >= spell.MatchDateTime.AddSeconds(spell.RecastTime))
                     {
                         spell.MatchDateTime = DateTime.Now;
+                        spell.UpdateDone = false;
                         spell.OverDone = false;
                         spell.TimeupDone = false;
                     }

--- a/ACT.SpecialSpellTimer/SpellTimerListWindow.xaml.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerListWindow.xaml.cs
@@ -290,7 +290,17 @@
                 c.BarColor = spell.BarColor;
                 c.BarOutlineColor = spell.BarOutlineColor;
 
-                if (spell.MatchDateTime > DateTime.MinValue)
+                // 一度もログにマッチしていない時はバーを初期化する
+                if (spell.MatchDateTime == DateTime.MinValue && !spell.UpdateDone)
+                {
+                    c.Progress = 1.0;
+                    c.RecastTime = 0;
+                    c.Update();
+                    c.StartBarAnimation();
+
+                    spell.UpdateDone = true;
+                }
+                else
                 {
                     c.RecastTime = (spell.CompleteScheduledTime - DateTime.Now).TotalSeconds;
                     if (c.RecastTime < 0)
@@ -305,6 +315,14 @@
                     if (c.Progress > 1.0d)
                     {
                         c.Progress = 1.0d;
+                    }
+
+                    if (!spell.UpdateDone)
+                    {
+                        c.Update();
+                        c.StartBarAnimation();
+
+                        spell.UpdateDone = true;
                     }
                 }
 

--- a/ACT.SpecialSpellTimer/SpellTimerTable.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerTable.cs
@@ -577,6 +577,8 @@
         [XmlIgnore]
         public DateTime CompleteScheduledTime { get; set; }
         [XmlIgnore]
+        public volatile bool UpdateDone;
+        [XmlIgnore]
         public bool OverDone { get; set; }
         [XmlIgnore]
         public bool BeforeDone { get; set; }

--- a/ACT.SpecialSpellTimer/app.config
+++ b/ACT.SpecialSpellTimer/app.config
@@ -88,6 +88,9 @@
       <setting name="OverText" serializeAs="String">
         <value>Over</value>
       </setting>
+      <setting name="MaxFPS" serializeAs="String">
+        <value>15</value>
+      </setting>
     </ACT.SpecialSpellTimer.Properties.Settings>
   </userSettings>
   <startup>


### PR DESCRIPTION
スペルタイマーのバー表示を下記のように変更しました。

* Widthの変更ではなく、ScaleTransformとDoubleAnimationの組み合わせを用いるようにした。
* バーの長さとリキャスト時間から個別にFPSを設定するようにした。（最大で15FPS）

これにより、FPSが低くなる設定（バーが短いなど）の場合に負荷が軽減されます。

ただ反対に、設定によっては（バーが長くリキャスト時間が短い場合には）従来より負荷が少し増えます。最大FPSを下げれば、負荷も従来程度になるのですが、表示の滑らかさを優先して15にしてみました。

またScaleTransformの利用で負荷が下がることも期待したのですが、表示負荷はDropShadowEffectが大半を占めているようで、そちらについては特に効果はありませんでした。
