### PR TITLE
ジョブチェンジ後にスペルが再描画されない問題を修正した

### DIFF
--- a/ACT.SpecialSpellTimer/LogBuffer.cs
+++ b/ACT.SpecialSpellTimer/LogBuffer.cs
@@ -401,6 +401,9 @@
             // 置換後のマッチングキーワードを消去する
             SpellTimerTable.ClearReplacedKeywords();
             OnePointTelopTable.Default.ClearReplacedKeywords();
+
+            // スペルタイマーの再描画を行う
+            SpellTimerTable.ClearUpdateFlags();
         }
 
         /// <summary>

--- a/ACT.SpecialSpellTimer/SpellTimerTable.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerTable.cs
@@ -238,6 +238,17 @@
         }
 
         /// <summary>
+        /// スペルの再描画フラグをクリアする
+        /// </summary>
+        public static void ClearUpdateFlags()
+        {
+            foreach (var item in Table)
+            {
+                item.UpdateDone = false;
+            }
+        }
+
+        /// <summary>
         /// デフォルトのファイル
         /// </summary>
         public static string DefaultFile


### PR DESCRIPTION
ジョブチェンジ後にスペルが再描画されない問題を修正しました。

ジョブチェンジ等で表示状態が変化した場合に、描画フラグを戻す処理が抜けていました。
