### PR TITLE
カスタムプレースホルダー機能の追加及びバグ修正を行いました。

### DIFF
--- a/ACT.SpecialSpellTimer/ConfigPanel.OnePointTelop.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.OnePointTelop.cs
@@ -61,6 +61,9 @@
                     source.Enabled = e1.Node.Checked;
                 }
 
+                // キャッシュを無効にする
+                OnePointTelopTable.Default.ClearReplacedKeywords();
+
                 // テロップの有効・無効が変化した際に、標準のスペルタイマーに反映する
                 SpellTimerCore.Default.applyToNormalSpellTimer();
             };

--- a/ACT.SpecialSpellTimer/ConfigPanel.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.cs
@@ -151,6 +151,9 @@
                     }
                 }
 
+                // キャッシュを無効にする
+                SpellTimerTable.ClearReplacedKeywords();
+
                 // スペルの有効・無効が変化した際に、標準のスペルタイマーに反映する
                 SpellTimerCore.Default.applyToNormalSpellTimer();
             };

--- a/ACT.SpecialSpellTimer/ConfigPanel.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.cs
@@ -642,13 +642,10 @@
                     n.Checked = children.Any(x => x.Checked);
 
                     this.SpellTimerTreeView.Nodes.Add(n);
-
-                    // バー表示の初期化が必要なことを記録
-                    foreach (var spell in spells)
-                    {
-                        spell.UpdateDone = false;
-                    }
                 }
+
+                // スペルの再描画を行わせる
+                SpellTimerTable.ClearUpdateFlags();
 
                 // 標準のスペルタイマーへ変更を反映する
                 SpellTimerCore.Default.applyToNormalSpellTimer();

--- a/ACT.SpecialSpellTimer/LogBuffer.cs
+++ b/ACT.SpecialSpellTimer/LogBuffer.cs
@@ -36,6 +36,11 @@
         private static List<KeyValuePair<string, string>> replacementsByJobs;
 
         /// <summary>
+        /// カスタム代名詞による置換文字列のセット
+        /// </summary>
+        private static Dictionary<string, string> customPlaceholders = new Dictionary<string, string>();
+
+        /// <summary>
         /// ペットのID
         /// </summary>
         private static string petid;
@@ -266,6 +271,13 @@
                 }
             }
 
+            // カスタムプレースホルダを置換する
+            // ex. <C1>, <C2> <focus> <ターゲット>...
+            foreach (var p in customPlaceholders)
+            {
+                keyword = keyword.Replace("<" + p.Key + ">", p.Value);
+            }
+
             return keyword;
         }
 
@@ -439,6 +451,45 @@
                     OnePointTelopTable.Default.ClearReplacedKeywords();
                 }
             }
+        }
+
+        /// <summary>
+        /// カスタムプレースホルダーに追加する
+        /// <param name="name">追加するプレースホルダーの名称</param>
+        /// <param name="value">置換する文字列</param>
+        /// </summary>
+        public static void SetCustomPlaceholder(string name, string value)
+        {
+            customPlaceholders[name] = value;
+
+            // 置換後のマッチングキーワードを消去する
+            SpellTimerTable.ClearReplacedKeywords();
+            OnePointTelopTable.Default.ClearReplacedKeywords();
+        }
+
+        /// <summary>
+        /// カスタムプレースホルダーを削除する
+        /// <param name="name">削除するプレースホルダーの名称</param>
+        /// </summary>
+        public static void ClearCustomPlaceholder(string name)
+        {
+            customPlaceholders.Remove(name);
+
+            // 置換後のマッチングキーワードを消去する
+            SpellTimerTable.ClearReplacedKeywords();
+            OnePointTelopTable.Default.ClearReplacedKeywords();
+        }
+
+        /// <summary>
+        /// カスタムプレースホルダーを全て削除する
+        /// </summary>
+        public static void ClearCustomPlaceholderAll()
+        {
+            customPlaceholders.Clear();
+
+            // 置換後のマッチングキーワードを消去する
+            SpellTimerTable.ClearReplacedKeywords();
+            OnePointTelopTable.Default.ClearReplacedKeywords();
         }
     }
 }

--- a/ACT.SpecialSpellTimer/OnePointTelopTable.cs
+++ b/ACT.SpecialSpellTimer/OnePointTelopTable.cs
@@ -225,6 +225,9 @@
                 item.KeywordReplaced = string.Empty;
                 item.KeywordToHideReplaced = string.Empty;
             }
+
+            // 有効SpellTimerのキャッシュを無効にする
+            enabledTableTimeStamp = DateTime.MinValue;
         }
 
         /// <summary>

--- a/ACT.SpecialSpellTimer/SpellTimerCore.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerCore.cs
@@ -639,6 +639,12 @@
                         w.ToTransparentWindow();
                     }
 
+                    /// このパネルに属するスペルを再描画させる
+                    foreach (var spell in panel)
+                    {
+                        spell.UpdateDone = false;
+                    }
+                    
                     w.Show();
                 }
 

--- a/ACT.SpecialSpellTimer/SpellTimerTable.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerTable.cs
@@ -235,6 +235,9 @@
                 item.KeywordForExtendReplaced1 = string.Empty;
                 item.KeywordForExtendReplaced2 = string.Empty;
             }
+
+            // 有効SpellTimerのキャッシュを無効にする
+            enabledTableTimeStamp = DateTime.MinValue;
         }
 
         /// <summary>

--- a/ACT.SpecialSpellTimer/SpellTimerTable.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerTable.cs
@@ -241,7 +241,7 @@
         }
 
         /// <summary>
-        /// スペルの再描画フラグをクリアする
+        /// スペルの描画済みフラグをクリアする
         /// </summary>
         public static void ClearUpdateFlags()
         {

--- a/ACT.SpecialSpellTimer/TextCommandController.cs
+++ b/ACT.SpecialSpellTimer/TextCommandController.cs
@@ -14,7 +14,7 @@
         /// コマンド解析用の正規表現
         /// </summary>
         private static Regex regexCommand = new Regex(
-            @".*/spespe (?<command>refresh|changeenabled|analyze) (?<target>spells|telops|me|pt|pet|on|off)( (?<windowname>"".*""|all) (?<value>.*))*",
+            @".*/spespe (?<command>refresh|changeenabled|analyze|set|clear) (?<target>spells|telops|me|pt|pet|on|off|placeholder) ?(?<windowname>"".*""|all) ?(?<value>.*)",
             RegexOptions.Compiled |
             RegexOptions.IgnoreCase);
 
@@ -43,8 +43,8 @@
 
                 var command = match.Groups["command"].ToString().ToLower();
                 var target = match.Groups["target"].ToString().ToLower();
-                var windowname = match.Groups["windowname"].ToString().ToLower().Replace(@"""", string.Empty);
-                var valueAsText = match.Groups["value"].ToString().ToLower();
+                var windowname = match.Groups["windowname"].ToString().Replace(@"""", string.Empty);
+                var valueAsText = match.Groups["value"].ToString();
                 var value = false;
                 if (!bool.TryParse(valueAsText, out value))
                 {
@@ -149,6 +149,43 @@
                                     commandDone = true;
                                 }
 
+                                break;
+                        }
+
+                        break;
+
+                    case "set":
+                        switch (target)
+                        {
+                            case "placeholder":
+                                if (windowname.Trim().ToLower() != "all" &&
+                                    windowname.Trim() != string.Empty &&
+                                    valueAsText.Trim() != string.Empty)
+                                {
+                                    LogBuffer.SetCustomPlaceholder(windowname.Trim(), valueAsText.Trim());
+
+                                    commandDone = true;
+                                }
+                                break;
+                        }
+
+                        break;
+
+                    case "clear":
+                        switch (target)
+                        {
+                            case "placeholder":
+                                if (windowname.Trim().ToLower() == "all")
+                                {
+                                    LogBuffer.ClearCustomPlaceholderAll();
+
+                                    commandDone = true;
+                                } else if (windowname.Trim() != string.Empty)
+                                {
+                                    LogBuffer.ClearCustomPlaceholder(windowname.Trim());
+
+                                    commandDone = true;
+                                }
                                 break;
                         }
 


### PR DESCRIPTION
任意のプレースホルダーを設定できる、カスタムプレースホルダー機能を追加しました。
下記のコマンドで設定することができます。

コマンド | 説明
------------ | -----------
/spespe set placeholder "tag" 文字列 | &lt;tag&gt;から文字列への置き換えを有効にする
/spespe clear placeholder "tag" | &lt;tag&gt;による置換を無効にする
/spespe clear placeholder all | 全ての置換を無効にする

主な用途としては、パーティーリストでの並び順に関わらず特定のメンバーを指定する、&lt;focus&gt;の代わりに用いる、などを想定しています。

フォーカスターゲットに利用する場合は、下記のようなマクロを実行します。

    /mlock
    /focustarget <t>
    /echo /spespe clear placeholder "_focus"
    /echo /spespe set placeholder "_focus" <f>

その後は、マッチングワード内で&lt;_focus&gt;を指定することで、フォーカスターゲットした対象とマッチさせることができます。

また下記の不具合を修正しました。

　・オプション画面で適用を選択した際に、表示がおかしくなる問題を修正しました。
