### PR TITLE
タイマーの開始条件を設定できるようにしました

### DIFF
--- a/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.csproj
+++ b/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.csproj
@@ -105,6 +105,12 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Strings-JP.resx</DependentUpon>
     </Compile>
+    <Compile Include="SetConditionForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="SetConditionForm.Designer.cs">
+      <DependentUpon>SetConditionForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="SelectZoneForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -133,6 +139,7 @@
     <Compile Include="Utility\CaptionButtonPanel.xaml.cs">
       <DependentUpon>CaptionButtonPanel.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Utility\ConditionUtility.cs" />
     <Compile Include="Utility\FontDialogWindow.xaml.cs">
       <DependentUpon>FontDialogWindow.xaml</DependentUpon>
     </Compile>
@@ -282,6 +289,9 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Strings-JP.Designer.cs</LastGenOutput>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="SetConditionForm.resx">
+      <DependentUpon>SetConditionForm.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="SelectZoneForm.resx">
       <DependentUpon>SelectZoneForm.cs</DependentUpon>

--- a/ACT.SpecialSpellTimer/ConfigPanel.Designer.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.Designer.cs
@@ -44,6 +44,7 @@
             this.UpdatePanelButton = new System.Windows.Forms.Button();
             this.ClearAllButton = new System.Windows.Forms.Button();
             this.DetailGroupBox = new System.Windows.Forms.GroupBox();
+            this.SetConditionButton = new System.Windows.Forms.Button();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPage1 = new System.Windows.Forms.TabPage();
             this.ReduceIconBrightnessCheckBox = new System.Windows.Forms.CheckBox();
@@ -126,6 +127,7 @@
             this.SpellTimerTreeView = new System.Windows.Forms.TreeView();
             this.OnPointTelopTabPage = new System.Windows.Forms.TabPage();
             this.TelopDetailGroupBox = new System.Windows.Forms.GroupBox();
+            this.TelopSetConditionButton = new System.Windows.Forms.Button();
             this.TelopSelectZoneButton = new System.Windows.Forms.Button();
             this.TelopVisualSetting = new ACT.SpecialSpellTimer.VisualSettingControl();
             this.TelopSelectJobButton = new System.Windows.Forms.Button();
@@ -199,6 +201,10 @@
             this.CombatAnalyzingLabel = new System.Windows.Forms.Label();
             this.AnalyzeCombatButton = new System.Windows.Forms.Button();
             this.OptionTabPage = new System.Windows.Forms.TabPage();
+            this.OverTextBox = new System.Windows.Forms.TextBox();
+            this.label66 = new System.Windows.Forms.Label();
+            this.ReadyTextBox = new System.Windows.Forms.TextBox();
+            this.label65 = new System.Windows.Forms.Label();
             this.label64 = new System.Windows.Forms.Label();
             this.EnabledNotifyNormalSpellTimerCheckBox = new System.Windows.Forms.CheckBox();
             this.label63 = new System.Windows.Forms.Label();
@@ -239,10 +245,6 @@
             this.ToolTip = new System.Windows.Forms.ToolTip(this.components);
             this.CombatAnalyzingTimer = new System.Windows.Forms.Timer(this.components);
             this.EnabledSpellTimerNoDecimal = new System.Windows.Forms.CheckBox();
-            this.label65 = new System.Windows.Forms.Label();
-            this.ReadyTextBox = new System.Windows.Forms.TextBox();
-            this.label66 = new System.Windows.Forms.Label();
-            this.OverTextBox = new System.Windows.Forms.TextBox();
             this.TabControl.SuspendLayout();
             this.SpecialSpellTabPage.SuspendLayout();
             this.DetailPanelGroupBox.SuspendLayout();
@@ -471,6 +473,7 @@
             this.DetailGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.DetailGroupBox.Controls.Add(this.SetConditionButton);
             this.DetailGroupBox.Controls.Add(this.tabControl1);
             this.DetailGroupBox.Controls.Add(this.SelectZoneButton);
             this.DetailGroupBox.Controls.Add(this.SelectJobButton);
@@ -481,6 +484,16 @@
             this.DetailGroupBox.Size = new System.Drawing.Size(850, 662);
             this.DetailGroupBox.TabIndex = 5;
             this.DetailGroupBox.TabStop = false;
+            // 
+            // SetConditionButton
+            // 
+            this.SetConditionButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.SetConditionButton.Location = new System.Drawing.Point(306, 631);
+            this.SetConditionButton.Name = "SetConditionButton";
+            this.SetConditionButton.Size = new System.Drawing.Size(144, 25);
+            this.SetConditionButton.TabIndex = 36;
+            this.SetConditionButton.Text = "SetConditionForStartButton";
+            this.SetConditionButton.UseVisualStyleBackColor = true;
             // 
             // tabControl1
             // 
@@ -1396,6 +1409,7 @@
             this.TelopDetailGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.TelopDetailGroupBox.Controls.Add(this.TelopSetConditionButton);
             this.TelopDetailGroupBox.Controls.Add(this.TelopSelectZoneButton);
             this.TelopDetailGroupBox.Controls.Add(this.TelopVisualSetting);
             this.TelopDetailGroupBox.Controls.Add(this.TelopSelectJobButton);
@@ -1430,6 +1444,16 @@
             this.TelopDetailGroupBox.Size = new System.Drawing.Size(850, 662);
             this.TelopDetailGroupBox.TabIndex = 5;
             this.TelopDetailGroupBox.TabStop = false;
+            // 
+            // TelopSetConditionButton
+            // 
+            this.TelopSetConditionButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.TelopSetConditionButton.Location = new System.Drawing.Point(306, 631);
+            this.TelopSetConditionButton.Name = "TelopSetConditionButton";
+            this.TelopSetConditionButton.Size = new System.Drawing.Size(144, 25);
+            this.TelopSetConditionButton.TabIndex = 47;
+            this.TelopSetConditionButton.Text = "SetConditionForStartButton";
+            this.TelopSetConditionButton.UseVisualStyleBackColor = true;
             // 
             // TelopSelectZoneButton
             // 
@@ -2040,26 +2064,26 @@
             this.toolStripSeparator2,
             this.CASetOriginItem});
             this.CombatAnalyzerContextMenuStrip.Name = "CombatAnalyzerContextMenuStrip";
-            this.CombatAnalyzerContextMenuStrip.Size = new System.Drawing.Size(224, 104);
+            this.CombatAnalyzerContextMenuStrip.Size = new System.Drawing.Size(242, 104);
             // 
             // CASelectAllItem
             // 
             this.CASelectAllItem.Name = "CASelectAllItem";
             this.CASelectAllItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.A)));
-            this.CASelectAllItem.Size = new System.Drawing.Size(223, 22);
+            this.CASelectAllItem.Size = new System.Drawing.Size(241, 22);
             this.CASelectAllItem.Text = "SelectAll";
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(220, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(238, 6);
             // 
             // CACopyLogItem
             // 
             this.CACopyLogItem.Name = "CACopyLogItem";
             this.CACopyLogItem.ShortcutKeyDisplayString = "";
             this.CACopyLogItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-            this.CACopyLogItem.Size = new System.Drawing.Size(223, 22);
+            this.CACopyLogItem.Size = new System.Drawing.Size(241, 22);
             this.CACopyLogItem.Text = "CopyLog";
             // 
             // CACopyLogDetailItem
@@ -2067,19 +2091,19 @@
             this.CACopyLogDetailItem.Name = "CACopyLogDetailItem";
             this.CACopyLogDetailItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.C)));
-            this.CACopyLogDetailItem.Size = new System.Drawing.Size(223, 22);
+            this.CACopyLogDetailItem.Size = new System.Drawing.Size(241, 22);
             this.CACopyLogDetailItem.Text = "CopyLogDetail";
             // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(220, 6);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(238, 6);
             // 
             // CASetOriginItem
             // 
             this.CASetOriginItem.Name = "CASetOriginItem";
             this.CASetOriginItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-            this.CASetOriginItem.Size = new System.Drawing.Size(223, 22);
+            this.CASetOriginItem.Size = new System.Drawing.Size(241, 22);
             this.CASetOriginItem.Text = "SetLogOrigin";
             // 
             // label6
@@ -2201,6 +2225,38 @@
             this.OptionTabPage.Size = new System.Drawing.Size(1186, 668);
             this.OptionTabPage.TabIndex = 1;
             this.OptionTabPage.Text = "OptionTabPageTitle";
+            // 
+            // OverTextBox
+            // 
+            this.OverTextBox.Location = new System.Drawing.Point(293, 404);
+            this.OverTextBox.Name = "OverTextBox";
+            this.OverTextBox.Size = new System.Drawing.Size(100, 19);
+            this.OverTextBox.TabIndex = 51;
+            // 
+            // label66
+            // 
+            this.label66.AutoSize = true;
+            this.label66.Location = new System.Drawing.Point(6, 407);
+            this.label66.Name = "label66";
+            this.label66.Size = new System.Drawing.Size(79, 12);
+            this.label66.TabIndex = 50;
+            this.label66.Text = "OverTextLabel";
+            // 
+            // ReadyTextBox
+            // 
+            this.ReadyTextBox.Location = new System.Drawing.Point(293, 379);
+            this.ReadyTextBox.Name = "ReadyTextBox";
+            this.ReadyTextBox.Size = new System.Drawing.Size(100, 19);
+            this.ReadyTextBox.TabIndex = 49;
+            // 
+            // label65
+            // 
+            this.label65.AutoSize = true;
+            this.label65.Location = new System.Drawing.Point(6, 382);
+            this.label65.Name = "label65";
+            this.label65.Size = new System.Drawing.Size(87, 12);
+            this.label65.TabIndex = 48;
+            this.label65.Text = "ReadyTextLabel";
             // 
             // label64
             // 
@@ -2592,38 +2648,6 @@
             this.EnabledSpellTimerNoDecimal.Text = "Enabled";
             this.EnabledSpellTimerNoDecimal.UseVisualStyleBackColor = true;
             // 
-            // label65
-            // 
-            this.label65.AutoSize = true;
-            this.label65.Location = new System.Drawing.Point(6, 382);
-            this.label65.Name = "label65";
-            this.label65.Size = new System.Drawing.Size(87, 12);
-            this.label65.TabIndex = 48;
-            this.label65.Text = "ReadyTextLabel";
-            // 
-            // ReadyTextBox
-            // 
-            this.ReadyTextBox.Location = new System.Drawing.Point(293, 379);
-            this.ReadyTextBox.Name = "ReadyTextBox";
-            this.ReadyTextBox.Size = new System.Drawing.Size(100, 19);
-            this.ReadyTextBox.TabIndex = 49;
-            // 
-            // label66
-            // 
-            this.label66.AutoSize = true;
-            this.label66.Location = new System.Drawing.Point(6, 407);
-            this.label66.Name = "label66";
-            this.label66.Size = new System.Drawing.Size(79, 12);
-            this.label66.TabIndex = 50;
-            this.label66.Text = "OverTextLabel";
-            // 
-            // OverTextBox
-            // 
-            this.OverTextBox.Location = new System.Drawing.Point(293, 404);
-            this.OverTextBox.Name = "OverTextBox";
-            this.OverTextBox.Size = new System.Drawing.Size(100, 19);
-            this.OverTextBox.TabIndex = 51;
-            // 
             // ConfigPanel
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
@@ -2899,5 +2923,7 @@
         private System.Windows.Forms.Label label65;
         private System.Windows.Forms.TextBox OverTextBox;
         private System.Windows.Forms.Label label66;
+        private System.Windows.Forms.Button SetConditionButton;
+        private System.Windows.Forms.Button TelopSetConditionButton;
     }
 }

--- a/ACT.SpecialSpellTimer/ConfigPanel.OnePointTelop.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.OnePointTelop.cs
@@ -112,6 +112,30 @@
                 }
             };
 
+            this.TelopSetConditionButton.Click += (s1, e1) =>
+            {
+                var src = this.TelopDetailGroupBox.Tag as OnePointTelop;
+                if (src != null)
+                {
+                    using (var f = new SetConditionForm())
+                    {
+                        f.TimersMustRunning = src.TimersMustRunningForStart;
+                        f.TimersMustStopping = src.TimersMustStoppingForStart;
+                        if (f.ShowDialog(this) == DialogResult.OK)
+                        {
+                            src.TimersMustRunningForStart = f.TimersMustRunning;
+                            src.TimersMustStoppingForStart = f.TimersMustStopping;
+
+                            // 条件設定ボタンの色を変える（未設定：黒、設定有：青）
+                            this.TelopSetConditionButton.ForeColor =
+                                (src.TimersMustRunningForStart.Length != 0 || src.TimersMustStoppingForStart.Length != 0) ?
+                                Color.Blue :
+                                Button.DefaultForeColor;
+                        }
+                    }
+                }
+            };
+
             this.TelopExportButton.Click += this.TelopExportButton_Click;
             this.TelopImportButton.Click += this.TelopImportButton_Click;
             this.TelopClearAllButton.Click += this.TelopClearAllButton_Click;
@@ -204,6 +228,8 @@
             nr.Top = 10.0d;
             nr.JobFilter = string.Empty;
             nr.ZoneFilter = string.Empty;
+            nr.TimersMustRunningForStart = new Guid[0];
+            nr.TimersMustStoppingForStart = new Guid[0];
 
             // 現在選択しているノードの情報を一部コピーする
             if (this.TelopTreeView.SelectedNode != null)
@@ -235,6 +261,8 @@
                     nr.Top = baseRow.Top;
                     nr.JobFilter = baseRow.JobFilter;
                     nr.ZoneFilter = baseRow.ZoneFilter;
+                    nr.TimersMustRunningForStart = baseRow.TimersMustRunningForStart;
+                    nr.TimersMustStoppingForStart = baseRow.TimersMustStoppingForStart;
                 }
             }
 
@@ -266,6 +294,12 @@
 
             // ゾーン限定ボタンの色を変える（未設定：黒、設定有：青）
             this.TelopSelectZoneButton.ForeColor = nr.ZoneFilter != string.Empty ? Color.Blue : Button.DefaultForeColor;
+
+            // 条件設定ボタンの色を変える（未設定：黒、設定有：青）
+            this.TelopSetConditionButton.ForeColor =
+                (nr.TimersMustRunningForStart.Length != 0 || nr.TimersMustStoppingForStart.Length != 0) ?
+                Color.Blue :
+                Button.DefaultForeColor;
 
             // 標準のスペルタイマーへ変更を反映する
             SpellTimerCore.Default.applyToNormalSpellTimer();
@@ -494,6 +528,12 @@
 
             // ゾーン限定ボタンの色を変える（未設定：黒、設定有：青）
             this.TelopSelectZoneButton.ForeColor = src.ZoneFilter != string.Empty ? Color.Blue : Button.DefaultForeColor;
+
+            // 条件設定ボタンの色を変える（未設定：黒、設定有：青）
+            this.TelopSetConditionButton.ForeColor =
+                (src.TimersMustRunningForStart.Length != 0 || src.TimersMustStoppingForStart.Length != 0) ?
+                Color.Blue :
+                Button.DefaultForeColor;
         }
     }
 }

--- a/ACT.SpecialSpellTimer/ConfigPanel.OnePointTelop.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.OnePointTelop.cs
@@ -191,6 +191,7 @@
             nr.ID = OnePointTelopTable.Default.Table.Any() ?
                 OnePointTelopTable.Default.Table.Max(x => x.ID) + 1 :
                 1;
+            nr.guid = Guid.NewGuid();
             nr.Title = Translate.Get("NewTelop");
             nr.DisplayTime = 3;
             nr.FontColor = Settings.Default.FontColor.ToHTML();

--- a/ACT.SpecialSpellTimer/ConfigPanel.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.cs
@@ -244,6 +244,7 @@
                 nr.ID = SpellTimerTable.Table.Any() ?
                     SpellTimerTable.Table.Max(x => x.ID) + 1 :
                     1;
+                nr.guid = Guid.NewGuid();
                 nr.Panel = "General";
                 nr.SpellTitle = "New Spell";
                 nr.SpellIcon = string.Empty;

--- a/ACT.SpecialSpellTimer/ConfigPanel.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.cs
@@ -196,6 +196,31 @@
                 }
             };
 
+            this.SetConditionButton.Click += (s1, e1) =>
+            {
+                var src = this.DetailGroupBox.Tag as SpellTimer;
+                if (src != null)
+                {
+                    using (var f = new SetConditionForm())
+                    {
+                        f.TimersMustRunning = src.TimersMustRunningForStart;
+                        f.TimersMustStopping = src.TimersMustStoppingForStart;
+
+                        if (f.ShowDialog(this) == DialogResult.OK)
+                        {
+                            src.TimersMustRunningForStart = f.TimersMustRunning;
+                            src.TimersMustStoppingForStart = f.TimersMustStopping;
+
+                            // 条件設定ボタンの色を変える（未設定：黒、設定有：青）
+                            this.SetConditionButton.ForeColor =
+                                (src.TimersMustRunningForStart.Length != 0 || src.TimersMustStoppingForStart.Length != 0) ?
+                                Color.Blue :
+                                Button.DefaultForeColor;
+                        }
+                    }
+                }
+            };
+
             this.SpellIconComboBox.SelectionChangeCommitted += (s1, e1) =>
             {
                 this.SpellVisualSetting.SpellIcon = (string)this.SpellIconComboBox.SelectedValue;
@@ -262,6 +287,8 @@
                 nr.BackgroundColor = Settings.Default.BackgroundColor.ToHTML();
                 nr.JobFilter = string.Empty;
                 nr.ZoneFilter = string.Empty;
+                nr.TimersMustRunningForStart = new Guid[0];
+                nr.TimersMustStoppingForStart = new Guid[0];
 
                 // 現在選択しているノードの情報を一部コピーする
                 if (this.SpellTimerTreeView.SelectedNode != null)
@@ -306,6 +333,8 @@
                         nr.BackgroundAlpha = baseRow.BackgroundAlpha;
                         nr.JobFilter = baseRow.JobFilter;
                         nr.ZoneFilter = baseRow.ZoneFilter;
+                        nr.TimersMustRunningForStart = baseRow.TimersMustRunningForStart;
+                        nr.TimersMustStoppingForStart = baseRow.TimersMustStoppingForStart;
                     }
                 }
 
@@ -358,6 +387,12 @@
 
                 // ジョブ限定ボタンの色を変える（未設定：黒、設定有：青）
                 this.SelectJobButton.ForeColor = nr.JobFilter != string.Empty ? Color.Blue : Button.DefaultForeColor;
+
+                // 条件設定ボタンの色を変える（未設定：黒、設定有：青）
+                this.SetConditionButton.ForeColor =
+                    (nr.TimersMustRunningForStart.Length != 0 || nr.TimersMustStoppingForStart.Length != 0) ?
+                    Color.Blue :
+                    Button.DefaultForeColor;
             }
 
             // 標準のスペルタイマーへ変更を反映する
@@ -758,6 +793,12 @@
 
             // ジョブ限定ボタンの色を変える（未設定：黒、設定有：青）
             this.SelectJobButton.ForeColor = src.JobFilter != string.Empty ? Color.Blue : Button.DefaultForeColor;
+
+            // 条件設定ボタンの色を変える（未設定：黒、設定有：青）
+            this.SetConditionButton.ForeColor =
+                (src.TimersMustRunningForStart.Length != 0 || src.TimersMustStoppingForStart.Length != 0) ?
+                Color.Blue :
+                Button.DefaultForeColor;
         }
 
         /// <summary>

--- a/ACT.SpecialSpellTimer/OnePointTelopTable.cs
+++ b/ACT.SpecialSpellTimer/OnePointTelopTable.cs
@@ -231,6 +231,15 @@
         }
 
         /// <summary>
+        /// 指定されたGuidを持つOnePointTelopを取得する
+        /// </summary>
+        /// <param name="guid">Guid</param>
+        public OnePointTelop GetOnePointTelopByGuid(Guid guid)
+        {
+            return table.Where(x => x.guid == guid).FirstOrDefault();
+        }
+
+        /// <summary>
         /// デフォルトのファイル
         /// </summary>
         public string DefaultFile
@@ -257,6 +266,10 @@
             {
                 id++;
                 row.ID = id;
+                if (row.guid == Guid.Empty)
+                {
+                    row.guid = Guid.NewGuid();
+                }
                 row.MatchDateTime = DateTime.MinValue;
                 row.Regex = null;
                 row.RegexPattern = string.Empty;
@@ -452,6 +465,7 @@
     {
         public OnePointTelop()
         {
+            this.guid = Guid.Empty;
             this.Title = string.Empty;
             this.Keyword = string.Empty;
             this.KeywordToHide = string.Empty;
@@ -476,6 +490,7 @@
         }
 
         public long ID { get; set; }
+        public Guid guid { get; set; }
         public string Title { get; set; }
         public string Keyword { get; set; }
         public string KeywordToHide { get; set; }

--- a/ACT.SpecialSpellTimer/OnePointTelopTable.cs
+++ b/ACT.SpecialSpellTimer/OnePointTelopTable.cs
@@ -484,6 +484,8 @@
             this.RegexPatternToHide = string.Empty;
             this.JobFilter = string.Empty;
             this.ZoneFilter = string.Empty;
+            this.TimersMustRunningForStart = new Guid[0];
+            this.TimersMustStoppingForStart = new Guid[0];
             this.Font = new FontInfo();
             this.KeywordReplaced = string.Empty;
             this.KeywordToHideReplaced = string.Empty;
@@ -516,6 +518,8 @@
         public double Top { get; set; }
         public string JobFilter { get; set; }
         public string ZoneFilter { get; set; }
+        public Guid[] TimersMustRunningForStart { get; set; }
+        public Guid[] TimersMustStoppingForStart { get; set; }
         public bool Enabled { get; set; }
 
         [XmlIgnore]

--- a/ACT.SpecialSpellTimer/SetConditionForm.Designer.cs
+++ b/ACT.SpecialSpellTimer/SetConditionForm.Designer.cs
@@ -1,0 +1,214 @@
+﻿namespace ACT.SpecialSpellTimer
+{
+    partial class SetConditionForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.label2 = new System.Windows.Forms.Label();
+            this.label1 = new System.Windows.Forms.Label();
+            this.SpellMustStoppingTreeView = new System.Windows.Forms.TreeView();
+            this.SpellMustRunningTreeView = new System.Windows.Forms.TreeView();
+            this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.label4 = new System.Windows.Forms.Label();
+            this.label3 = new System.Windows.Forms.Label();
+            this.TelopMustStoppingTreeView = new System.Windows.Forms.TreeView();
+            this.TelopMustRunningTreeView = new System.Windows.Forms.TreeView();
+            this.CloseButton = new System.Windows.Forms.Button();
+            this.OKButton = new System.Windows.Forms.Button();
+            this.AllOFFButton = new System.Windows.Forms.Button();
+            this.groupBox1.SuspendLayout();
+            this.groupBox2.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Controls.Add(this.label2);
+            this.groupBox1.Controls.Add(this.label1);
+            this.groupBox1.Controls.Add(this.SpellMustStoppingTreeView);
+            this.groupBox1.Controls.Add(this.SpellMustRunningTreeView);
+            this.groupBox1.Location = new System.Drawing.Point(12, 12);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(480, 485);
+            this.groupBox1.TabIndex = 0;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "SpellTimerTabTitle";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(241, 22);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(58, 12);
+            this.label2.TabIndex = 3;
+            this.label2.Text = "IsStopping";
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(4, 22);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(55, 12);
+            this.label1.TabIndex = 2;
+            this.label1.Text = "IsRunning";
+            // 
+            // SpellMustStoppingTreeView
+            // 
+            this.SpellMustStoppingTreeView.CheckBoxes = true;
+            this.SpellMustStoppingTreeView.Location = new System.Drawing.Point(244, 41);
+            this.SpellMustStoppingTreeView.Name = "SpellMustStoppingTreeView";
+            this.SpellMustStoppingTreeView.ShowNodeToolTips = true;
+            this.SpellMustStoppingTreeView.Size = new System.Drawing.Size(230, 435);
+            this.SpellMustStoppingTreeView.TabIndex = 1;
+            // 
+            // SpellMustRunningTreeView
+            // 
+            this.SpellMustRunningTreeView.CheckBoxes = true;
+            this.SpellMustRunningTreeView.Location = new System.Drawing.Point(6, 41);
+            this.SpellMustRunningTreeView.Name = "SpellMustRunningTreeView";
+            this.SpellMustRunningTreeView.ShowNodeToolTips = true;
+            this.SpellMustRunningTreeView.Size = new System.Drawing.Size(230, 435);
+            this.SpellMustRunningTreeView.TabIndex = 0;
+            // 
+            // groupBox2
+            // 
+            this.groupBox2.Controls.Add(this.label4);
+            this.groupBox2.Controls.Add(this.label3);
+            this.groupBox2.Controls.Add(this.TelopMustStoppingTreeView);
+            this.groupBox2.Controls.Add(this.TelopMustRunningTreeView);
+            this.groupBox2.Location = new System.Drawing.Point(516, 12);
+            this.groupBox2.Name = "groupBox2";
+            this.groupBox2.Size = new System.Drawing.Size(480, 485);
+            this.groupBox2.TabIndex = 1;
+            this.groupBox2.TabStop = false;
+            this.groupBox2.Text = "TelopTabPageTitle";
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Location = new System.Drawing.Point(254, 22);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(58, 12);
+            this.label4.TabIndex = 4;
+            this.label4.Text = "IsStopping";
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(6, 22);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(55, 12);
+            this.label3.TabIndex = 3;
+            this.label3.Text = "IsRunning";
+            // 
+            // TelopMustStoppingTreeView
+            // 
+            this.TelopMustStoppingTreeView.CheckBoxes = true;
+            this.TelopMustStoppingTreeView.Location = new System.Drawing.Point(244, 41);
+            this.TelopMustStoppingTreeView.Name = "TelopMustStoppingTreeView";
+            this.TelopMustStoppingTreeView.ShowNodeToolTips = true;
+            this.TelopMustStoppingTreeView.Size = new System.Drawing.Size(230, 435);
+            this.TelopMustStoppingTreeView.TabIndex = 1;
+            // 
+            // TelopMustRunningTreeView
+            // 
+            this.TelopMustRunningTreeView.CheckBoxes = true;
+            this.TelopMustRunningTreeView.Location = new System.Drawing.Point(6, 41);
+            this.TelopMustRunningTreeView.Name = "TelopMustRunningTreeView";
+            this.TelopMustRunningTreeView.ShowNodeToolTips = true;
+            this.TelopMustRunningTreeView.Size = new System.Drawing.Size(230, 435);
+            this.TelopMustRunningTreeView.TabIndex = 0;
+            // 
+            // CloseButton
+            // 
+            this.CloseButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.CloseButton.Location = new System.Drawing.Point(894, 505);
+            this.CloseButton.Name = "CloseButton";
+            this.CloseButton.Size = new System.Drawing.Size(102, 26);
+            this.CloseButton.TabIndex = 2;
+            this.CloseButton.Text = "CancelButton";
+            this.CloseButton.UseVisualStyleBackColor = true;
+            // 
+            // OKButton
+            // 
+            this.OKButton.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.OKButton.Location = new System.Drawing.Point(770, 505);
+            this.OKButton.Name = "OKButton";
+            this.OKButton.Size = new System.Drawing.Size(118, 25);
+            this.OKButton.TabIndex = 3;
+            this.OKButton.Text = "OKButton";
+            this.OKButton.UseVisualStyleBackColor = true;
+            this.OKButton.Click += new System.EventHandler(this.OKButton_Click);
+            // 
+            // AllOFFButton
+            // 
+            this.AllOFFButton.Location = new System.Drawing.Point(12, 505);
+            this.AllOFFButton.Name = "AllOFFButton";
+            this.AllOFFButton.Size = new System.Drawing.Size(118, 25);
+            this.AllOFFButton.TabIndex = 4;
+            this.AllOFFButton.Text = "AllOffButton";
+            this.AllOFFButton.UseVisualStyleBackColor = true;
+            this.AllOFFButton.Click += new System.EventHandler(this.AllOFFButton_Click);
+            // 
+            // SetConditionForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(1008, 535);
+            this.Controls.Add(this.AllOFFButton);
+            this.Controls.Add(this.OKButton);
+            this.Controls.Add(this.CloseButton);
+            this.Controls.Add(this.groupBox2);
+            this.Controls.Add(this.groupBox1);
+            this.Name = "SetConditionForm";
+            this.Text = "SetConditionTitle";
+            this.Load += new System.EventHandler(this.SelectConditionForm_Load);
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
+            this.groupBox2.ResumeLayout(false);
+            this.groupBox2.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.GroupBox groupBox2;
+        private System.Windows.Forms.TreeView SpellMustStoppingTreeView;
+        private System.Windows.Forms.TreeView SpellMustRunningTreeView;
+        private System.Windows.Forms.TreeView TelopMustStoppingTreeView;
+        private System.Windows.Forms.TreeView TelopMustRunningTreeView;
+        private System.Windows.Forms.Button CloseButton;
+        private System.Windows.Forms.Button OKButton;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Button AllOFFButton;
+    }
+}

--- a/ACT.SpecialSpellTimer/SetConditionForm.cs
+++ b/ACT.SpecialSpellTimer/SetConditionForm.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace ACT.SpecialSpellTimer
+{
+    public partial class SetConditionForm : Form
+    {
+        public SetConditionForm()
+        {
+            InitializeComponent();
+            Utility.Translate.TranslateControls(this);
+        }
+
+        public Guid[] TimersMustRunning { get; set; }
+
+        public Guid[] TimersMustStopping { get; set; }
+
+        private void SelectConditionForm_Load(object sender, EventArgs e)
+        {
+            this.LoadSpells(this.SpellMustRunningTreeView, this.TimersMustRunning);
+            this.LoadSpells(this.SpellMustStoppingTreeView, this.TimersMustStopping);
+            this.LoadTelops(this.TelopMustRunningTreeView, this.TimersMustRunning);
+            this.LoadTelops(this.TelopMustStoppingTreeView, this.TimersMustStopping);
+        }
+
+        /// <summary>
+        /// TreeViewにSpellTimer一覧を読み込む
+        /// その際、指定されたGuidに対応するSpellTimerにチェックを付ける
+        /// </summary>
+        /// <param name="treeView">読み込み先のTreeView</param>
+        /// <param name="checks">チェックをつけるSpellTimerのGuid</param>
+        private void LoadSpells(TreeView treeView, Guid[] checks)
+        {
+            treeView.Nodes.Clear();
+
+            var panels = SpellTimerTable.Table
+                .OrderBy(x => x.Panel)
+                .Select(x => x.Panel)
+                .Distinct();
+            foreach (var panelName in panels)
+            {
+                var children = new List<TreeNode>();
+                var spells = SpellTimerTable.Table
+                    .OrderBy(x => x.DisplayNo)
+                    .Where(x => x.Panel == panelName);
+                foreach (var spell in spells)
+                {
+                    var nc = new TreeNode()
+                    {
+                        Text = spell.SpellTitle,
+                        ToolTipText = spell.Keyword,
+                        Checked = Array.IndexOf(checks, spell.guid) != -1,
+                        Tag = spell,
+                    };
+
+                    children.Add(nc);
+                }
+
+                var n = new TreeNode(
+                    panelName,
+                    children.ToArray());
+
+                n.Checked = false;
+
+                treeView.Nodes.Add(n);
+            }
+
+            treeView.ExpandAll();
+        }
+
+        /// <summary>
+        /// TreeViewにOnePointTelop一覧を読み込む
+        /// その際、指定されたGuidに対応するOnePointTelopにチェックを付ける
+        /// </summary>
+        /// <param name="treeView">読み込み先のTreeView</param>
+        /// <param name="checks">チェックをつけるOnePointTelopのGuid</param>
+        private void LoadTelops(TreeView treeView, Guid[] checks)
+        {
+            treeView.Nodes.Clear();
+
+            var telops = OnePointTelopTable.Default.Table.OrderBy(x => x.Title);
+            foreach (var telop in telops)
+            {
+                var n = new TreeNode();
+
+                n.Tag = telop;
+                n.Text = telop.Title;
+                n.ToolTipText = telop.Message;
+                n.Checked = Array.IndexOf(checks, telop.guid) != -1;
+
+                treeView.Nodes.Add(n);
+            }
+
+            treeView.ExpandAll();
+        }
+
+        /// <summary>
+        /// TreeViewからチェックされたSpellTimerの一覧を取得する
+        /// </summary>
+        /// <param name="treeView">TreeView</param>
+        /// <returns>チェックされたSpellTimerを表すGuidの配列</returns>
+        private Guid[] GetCheckedSpells(TreeView treeView)
+        {
+            var spells = new List<Guid>();
+            foreach (TreeNode parent in treeView.Nodes)
+            {
+                foreach (TreeNode node in parent.Nodes)
+                {
+                    if (node.Checked)
+                    {
+                        var spell = (SpellTimer)node.Tag;
+                        spells.Add(spell.guid);
+                    }
+                }
+            }
+            return spells.ToArray();
+        }
+
+        /// <summary>
+        /// TreeViewからチェックされたOnePointTelopの一覧を取得する
+        /// </summary>
+        /// <param name="treeView">TreeView</param>
+        /// <returns>チェックされたOnePointTelopを表すGuidの配列</returns>
+        private Guid[] GetCheckedTelops(TreeView treeView)
+        {
+            var telops = new List<Guid>();
+            foreach (TreeNode node in treeView.Nodes)
+            {
+                if (node.Checked)
+                {
+                    var telop = (OnePointTelop)node.Tag;
+                    telops.Add(telop.guid);
+                }
+            }
+            return telops.ToArray();
+        }
+
+        private void AllOFFButton_Click(object sender, EventArgs e)
+        {
+            foreach(TreeNode node in this.SpellMustRunningTreeView.Nodes)
+            {
+                node.Checked = false;
+                foreach (TreeNode child in node.Nodes)
+                {
+                    child.Checked = false;
+                }
+            }
+            foreach (TreeNode node in this.SpellMustStoppingTreeView.Nodes)
+            {
+                node.Checked = false;
+                foreach (TreeNode child in node.Nodes)
+                {
+                    child.Checked = false;
+                }
+            }
+            foreach (TreeNode node in this.TelopMustRunningTreeView.Nodes)
+            {
+                node.Checked = false;
+            }
+            foreach (TreeNode node in this.TelopMustStoppingTreeView.Nodes)
+            {
+                node.Checked = false;
+            }
+        }
+
+        private void OKButton_Click(object sender, EventArgs e)
+        {
+            var s1 = this.GetCheckedSpells(this.SpellMustRunningTreeView);
+            var s2 = this.GetCheckedSpells(this.SpellMustStoppingTreeView);
+            var t1 = this.GetCheckedTelops(this.TelopMustRunningTreeView);
+            var t2 = this.GetCheckedTelops(this.TelopMustStoppingTreeView);
+
+            this.TimersMustRunning = s1.Concat(t1).ToArray();
+            this.TimersMustStopping = s2.Concat(t2).ToArray();
+        }
+    }
+}

--- a/ACT.SpecialSpellTimer/SetConditionForm.resx
+++ b/ACT.SpecialSpellTimer/SetConditionForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/ACT.SpecialSpellTimer/SpellTimerTable.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerTable.cs
@@ -547,6 +547,8 @@
             this.RegexPattern = string.Empty;
             this.JobFilter = string.Empty;
             this.ZoneFilter = string.Empty;
+            this.TimersMustRunningForStart = new Guid[0];
+            this.TimersMustStoppingForStart = new Guid[0];
             this.Font = new FontInfo();
             this.KeywordReplaced = string.Empty;
             this.KeywordForExtendReplaced1 = string.Empty;
@@ -601,6 +603,8 @@
         public bool RegexEnabled { get; set; }
         public string JobFilter { get; set; }
         public string ZoneFilter { get; set; }
+        public Guid[] TimersMustRunningForStart { get; set; }
+        public Guid[] TimersMustStoppingForStart { get; set; }
         public bool Enabled { get; set; }
 
         [XmlIgnore]

--- a/ACT.SpecialSpellTimer/SpellTimerTable.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerTable.cs
@@ -252,6 +252,15 @@
         }
 
         /// <summary>
+        /// 指定されたGuidを持つSpellTimerを取得する
+        /// </summary>
+        /// <param name="guid">Guid</param>
+        public static SpellTimer GetSpellTimerByGuid(Guid guid)
+        {
+            return table.Where(x => x.guid == guid).FirstOrDefault();
+        }
+
+        /// <summary>
         /// デフォルトのファイル
         /// </summary>
         public static string DefaultFile
@@ -278,6 +287,10 @@
             {
                 id++;
                 row.ID = id;
+                if (row.guid == Guid.Empty)
+                {
+                    row.guid = Guid.NewGuid();
+                }
                 row.MatchDateTime = DateTime.MinValue;
                 row.Regex = null;
                 row.RegexPattern = string.Empty;
@@ -510,6 +523,7 @@
     {
         public SpellTimer()
         {
+            this.guid = Guid.Empty;
             this.Panel = string.Empty;
             this.SpellTitle = string.Empty;
             this.SpellIcon = string.Empty;
@@ -540,6 +554,7 @@
         }
 
         public long ID { get; set; }
+        public Guid guid { get; set; }
         public string Panel { get; set; }
         public string SpellTitle { get; set; }
         public string SpellIcon { get; set; }

--- a/ACT.SpecialSpellTimer/Utility/ConditionUtility.cs
+++ b/ACT.SpecialSpellTimer/Utility/ConditionUtility.cs
@@ -1,0 +1,221 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace ACT.SpecialSpellTimer.Utility
+{
+    class ConditionUtility
+    {
+        /// <summary>
+        /// 指定されたSpellTimerの条件を確認する
+        /// </summary>
+        /// <param name="spell">SpellTimer</param>
+        /// <returns>条件を満たしていればtrue</returns>
+        public static bool CheckConditionsForSpell(SpellTimer spell)
+        {
+            return CheckConditions(spell.TimersMustRunningForStart, spell.TimersMustStoppingForStart);
+        }
+
+        /// <summary>
+        /// 指定されたOnePointTelopの条件を確認する
+        /// </summary>
+        /// <param name="telop">OnePointTelop</param>
+        /// <returns>条件を満たしていればtrue</returns>
+        public static bool CheckConditionsForTelop(OnePointTelop telop)
+        {
+            return CheckConditions(telop.TimersMustRunningForStart, telop.TimersMustStoppingForStart);
+        }
+
+        /// <summary>
+        /// 後方参照を置換したTitleを返す
+        /// </summary>
+        /// <param name="spell">SpellTimer</param>
+        /// <returns>置換後のTitle</returns>
+        public static string GetReplacedTitle(SpellTimer spell)
+        {
+            var builder = new StringBuilder(spell.SpellTitle);
+
+            int index = 1;
+            index += ReplaceMessageWithSpell(builder, spell.TimersMustRunningForStart, index);
+            index += ReplaceMessageWithSpell(builder, spell.TimersMustStoppingForStart, index);
+            index += ReplaceMessageWithTelop(builder, spell.TimersMustRunningForStart, index);
+            index += ReplaceMessageWithTelop(builder, spell.TimersMustStoppingForStart, index);
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// 後方参照を置換したMessageを返す
+        /// </summary>
+        /// <param name="telop">OnePointTelop</param>
+        /// <returns>置換後のMessage</returns>
+        public static string GetReplacedMessage(OnePointTelop telop)
+        {
+            var builder = new StringBuilder(telop.Message);
+            
+            int index = 1;
+            index += ReplaceMessageWithSpell(builder, telop.TimersMustRunningForStart, index);
+            index += ReplaceMessageWithSpell(builder, telop.TimersMustStoppingForStart, index);
+            index += ReplaceMessageWithTelop(builder, telop.TimersMustRunningForStart, index);
+            index += ReplaceMessageWithTelop(builder, telop.TimersMustStoppingForStart, index);
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// 指定されたGuidに対応するSpellTimerの後方参照で置換を行う
+        /// 置換文字列は "$C" + 条件の出現順（1～） + "-" + 後方参照の番号
+        /// 例： $C1-2（一つ目の条件となるタイマーの二つ目のグループに置換）
+        /// </summary>
+        /// <param name="message">元の文字列</param>
+        /// <param name="timers">置換候補のタイマー</param>
+        /// <param name="baseIndex">条件の出現順の開始番号</param>
+        /// <returns>候補となったタイマーの個数</returns>
+        private static int ReplaceMessageWithSpell(StringBuilder message, Guid[] timers, int baseIndex)
+        {
+            int count = 0;
+
+            for (int i = 0; i < timers.Length; i++)
+            {
+                var spell = SpellTimerTable.GetSpellTimerByGuid(timers[i]);
+                if (spell != null)
+                {
+                    count++;
+
+                    if (spell.RegexEnabled && spell.Regex != null && spell.MatchedLog != string.Empty)
+                    {
+                        foreach (Match match in spell.Regex.Matches(spell.MatchedLog))
+                        {
+                            foreach (var number in spell.Regex.GetGroupNumbers())
+                            {
+                                message.Replace(String.Format("$C{0}-{1}", (baseIndex + i), number), match.Groups[number].Value);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return count;
+        }
+
+        /// <summary>
+        /// 指定されたGuidに対応するOnePointTelopの後方参照で置換を行う
+        /// 置換文字列は "$C" + 条件の出現順（1～） + "-" + 後方参照の番号
+        /// 例： $C1-2（一つ目の条件となるタイマーの二つ目のグループに置換）
+        /// </summary>
+        /// <param name="message">元の文字列</param>
+        /// <param name="timers">置換候補のタイマー</param>
+        /// <param name="baseIndex">条件の出現順の開始番号</param>
+        /// <returns>候補となったタイマーの個数</returns>
+        private static int ReplaceMessageWithTelop(StringBuilder message, Guid[] timers, int baseIndex)
+        {
+            int count = 0;
+
+            for (int i = 0; i < timers.Length; i++)
+            {
+                var telop = OnePointTelopTable.Default.GetOnePointTelopByGuid(timers[i]);
+                if (telop != null)
+                {
+                    count++;
+
+                    if (telop != null && telop.RegexEnabled && telop.Regex != null && !string.IsNullOrEmpty(telop.MatchedLog))
+                    {
+                        foreach (Match match in telop.Regex.Matches(telop.MatchedLog))
+                        {
+                            foreach (var number in telop.Regex.GetGroupNumbers())
+                            {
+                                message.Replace(String.Format("$C{0}-{1}", (baseIndex + i), number), match.Groups[number].Value);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return count;
+        }
+
+        /// <summary>
+        /// 指定された全てのTimerが条件を満たしているか確認する
+        /// </summary>
+        /// <param name="timersMustRunning">稼働中であることが求められているTimerの配列</param>
+        /// <param name="timersMustStopping">停止中であることが求められているTimerの配列</param>
+        /// <returns>全てのTimerが条件を満たしていればtrue</returns>
+        private static bool CheckConditions(Guid[] timersMustRunning, Guid[] timersMustStopping)
+        {
+            if (timersMustRunning.Length == 0 && timersMustStopping.Length == 0)
+            {
+                return true;
+            }
+
+            // 動作中か確認する
+            var condition = true;
+            foreach (var guid in timersMustRunning)
+            {
+                var spell = SpellTimerTable.GetSpellTimerByGuid(guid);
+                if (spell != null)
+                {
+                    condition = condition & IsRunning(spell);
+                }
+
+                var telop = OnePointTelopTable.Default.GetOnePointTelopByGuid(guid);
+                if (telop != null)
+                {
+                    condition = condition & IsRunning(telop);
+                }
+            }
+
+            // 停止中か確認する（稼働中でなければ停止中として扱う）
+            foreach (var guid in timersMustStopping)
+            {
+                var spell = SpellTimerTable.GetSpellTimerByGuid(guid);
+                if (spell != null)
+                {
+                    condition = condition & !IsRunning(spell);
+                }
+
+                var telop = OnePointTelopTable.Default.GetOnePointTelopByGuid(guid);
+                if (telop != null)
+                {
+                    condition = condition & !IsRunning(telop);
+                }
+            }
+
+            return condition;
+        }
+
+        /// <summary>
+        /// 指定されたSpellTimerが稼働中か判定する
+        /// </summary>
+        /// <param name="spell">SpellTimer</param>
+        /// <returns>稼働中であればtrue</returns>
+        private static bool IsRunning(SpellTimer spell)
+        {
+            var recastTime = (spell.CompleteScheduledTime - DateTime.Now).TotalSeconds;
+            return recastTime >= 0;
+        }
+
+        /// <summary>
+        /// 指定されたOnePointTelopが稼働中か判定する
+        /// Delayがある場合はDelay経過後から稼働中として扱う
+        /// </summary>
+        /// <param name="telop">OnePointTelop</param>
+        /// <returns>稼働中であればtrue</returns>
+        private static bool IsRunning(OnePointTelop telop)
+        {
+            if (telop.MatchDateTime > DateTime.MinValue && !telop.ForceHide)
+            {
+                var start = telop.MatchDateTime.AddSeconds(telop.Delay);
+                var end = telop.MatchDateTime.AddSeconds(telop.Delay + telop.DisplayTime);
+
+                if (start <= DateTime.Now && DateTime.Now <= end)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-EN.Designer.cs
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-EN.Designer.cs
@@ -754,6 +754,24 @@ namespace ACT.SpecialSpellTimer.resources.strings {
         }
         
         /// <summary>
+        ///   Is Running に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string IsRunning {
+            get {
+                return ResourceManager.GetString("IsRunning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Is Stopping に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string IsStopping {
+            get {
+                return ResourceManager.GetString("IsStopping", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Language (言語) に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string LanguageLabel {
@@ -1452,6 +1470,24 @@ namespace ACT.SpecialSpellTimer.resources.strings {
         internal static string SelectZoneTitle {
             get {
                 return ResourceManager.GetString("SelectZoneTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Conditions for Start... に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string SetConditionForStartButton {
+            get {
+                return ResourceManager.GetString("SetConditionForStartButton", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Please select conditions に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string SetConditionTitle {
+            get {
+                return ResourceManager.GetString("SetConditionTitle", resourceCulture);
             }
         }
         

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-EN.resx
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-EN.resx
@@ -913,4 +913,20 @@
     <value>Text to display when the timer is complete (Ready)</value>
     <comment>スペルタイマが完了した時のテキスト(Ready)</comment>
   </data>
+  <data name="IsRunning" xml:space="preserve">
+    <value>Is Running</value>
+    <comment>稼働中</comment>
+  </data>
+  <data name="IsStopping" xml:space="preserve">
+    <value>Is Stopping</value>
+    <comment>停止中</comment>
+  </data>
+  <data name="SetConditionForStartButton" xml:space="preserve">
+    <value>Conditions for Start...</value>
+    <comment>開始条件を設定する</comment>
+  </data>
+  <data name="SetConditionTitle" xml:space="preserve">
+    <value>Please select conditions</value>
+    <comment>条件を設定して下さい</comment>
+  </data>
 </root>

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-JP.Designer.cs
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-JP.Designer.cs
@@ -754,6 +754,24 @@ namespace ACT.SpecialSpellTimer.resources.strings {
         }
         
         /// <summary>
+        ///   稼働中 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string IsRunning {
+            get {
+                return ResourceManager.GetString("IsRunning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   停止中 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string IsStopping {
+            get {
+                return ResourceManager.GetString("IsStopping", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   言語 (Language) に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string LanguageLabel {
@@ -1452,6 +1470,24 @@ namespace ACT.SpecialSpellTimer.resources.strings {
         internal static string SelectZoneTitle {
             get {
                 return ResourceManager.GetString("SelectZoneTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   開始条件を設定する に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string SetConditionForStartButton {
+            get {
+                return ResourceManager.GetString("SetConditionForStartButton", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   条件を設定して下さい に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string SetConditionTitle {
+            get {
+                return ResourceManager.GetString("SetConditionTitle", resourceCulture);
             }
         }
         

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-JP.resx
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-JP.resx
@@ -913,4 +913,20 @@
     <value>スペルタイマが完了した時のテキスト(Ready)</value>
     <comment>Text to display when the timer is complete (Ready)</comment>
   </data>
+  <data name="IsRunning" xml:space="preserve">
+    <value>稼働中</value>
+    <comment>Is Running</comment>
+  </data>
+  <data name="IsStopping" xml:space="preserve">
+    <value>停止中</value>
+    <comment>Is Stopping</comment>
+  </data>
+  <data name="SetConditionForStartButton" xml:space="preserve">
+    <value>開始条件を設定する</value>
+    <comment>Conditions for Start...</comment>
+  </data>
+  <data name="SetConditionTitle" xml:space="preserve">
+    <value>条件を設定して下さい</value>
+    <comment>Please select conditions</comment>
+  </data>
 </root>


### PR DESCRIPTION
タイマー（スペルタイマー、テロップ）の開始条件を設定できるようにしました。

特定のタイマーが「稼働」している、または「停止」している時のみ、そのタイマーの開始用マッチングワードをチェックさせることができます。（非表示や延長のマッチングワードは、条件の影響を受けず常にチェックされます）

また表示内容に、条件指定したタイマーの正規表現がキャプチャした内容を追加できるようにしました。表示メッセージ（スペルの名前）で下記の形式を指定することで、キャプチャされた内容に置き換わります。

    $C[条件番号]-[グループ番号]

例：左上から数えて2番目のタイマーのマッチングワードで、3番目に出現する ( ) に一致した内容

    $C2-3　

これらの機能を使うことで、次のようなことが実現できます。

## 占星術のカード効果時間
ロイヤルロード：効果時間増加の有無により、異なる（リキャスト時間の）タイマーを動作させる。

名称 | マッチングワード | 時間 | 条件
----|------|--------------|-----|----
効果時間増加 | loses the effect of ロイヤルロード：効果時間増加 | 2 | なし
アーゼマ30 | &lt;me&gt;の「アーゼマの均衡」 | 30 | 停止中：効果時間増加
アーゼマ60 | &lt;me&gt;の「アーゼマの均衡」 | 60 | 稼働中：効果時間増加

カードの効果はロイヤルロードが消えてから発動するため、ロイヤルロードが消えてから2秒間だけ「効果時間延長」が稼働するようにしています。

## アレキサンダー３層のマグネット表示
マグネットで自身とつながった相手の名前と、それぞれの＋ーの種類をテロップで表示させる。

名称 | 種別 | マッチングワード | 時間 | 条件 | メッセージ
----|------|--------------|-----|----|---------
磁力1 | ログ | (<2>&#124;<3>&#124;<4>&#124;<5>&#124;<6>&#124;<7>&#124;<8>)に「磁力【(.)】の効果</code> | 1 | 停止中：磁力1 | なし
  | 非表示 | (<2>&#124;<3>&#124;<4>&#124;<5>&#124;<6>&#124;<7>&#124;<8>)に「磁力【(.)】の効果 | | |
磁力2(奇数) | ログ | (<2>&#124;<3>&#124;<4>&#124;<5>&#124;<6>&#124;<7>&#124;<8>)に「磁力【(.)】の効果 | 6 | 稼働中：磁力3 | $2 $C1-1 => $1
磁力3 | ログ | &lt;me&gt;に「磁力【(.)】の効果 | 1 | 停止中：磁力1 | なし
  | 非表示 | (<2>&#124;<3>&#124;<4>&#124;<5>&#124;<6>&#124;<7>&#124;<8>)に「磁力【(.)】の効果 | | | 
磁力4(偶数) | ログ | &lt;me&gt;に「磁力【(.)】の効果 | 6 | 稼働中：磁力1 | $C1-2 $1 => $C1-1

これらの設定をすることで、[相手の＋ー] [自分の＋ー] => [相手の名前] のようにテロップを表示することができます。

磁力は、自身が奇数番目・偶数番目それぞれで、一つ前の人・一つ後の人とペアが異なるため、それぞれの場合を指定しています。

テロップでは、「ログに対するマッチングワード」に一致した場合、その行は「非表示にするマッチングワード」のチェックが行われないため、磁力1は１行ごとにON/OFFを繰り返します。そのため、磁力1を条件とすることで、結果的に奇数番目・偶数番目を条件とすることができています。


## ログ処理の変更について
開始条件を実現するために、ログの処理部分を下記のように変更しました。

     全ログ(foreach)
       全スペル(foreach)
         開始条件チェック(if)
           表示マッチング(if)
             continue（テロップの場合のみ）
         非表示・延長マッチング
     全スペル(foreach)
      音再生

主な変更点は下記の通りです。

* ログとスペルのループを入れ替えて、ログを1行ずつ処理するようにしました
* 表示マッチングを開始条件を満たした場合のみ行うようにしました

前者については、ログの処理順が重要となるための変更です。変更前とログ・スペルの組み合わせ自体は同じになるため、処理結果も同じになると考えています。ただ処理順の固定が必要となるため、将来的にParallelなどでの複数ログ・スペルの並列処理はできなくなるという懸念はあります。

後者については、開始条件チェックが増えてしまうのですが、条件未設定時は配列の長さチェックのみとなるため、処理速度には影響ないと考えています。
