### PR TITLE
アイコンサイズを6未満に設定した際に発生する問題を修正

### DIFF
--- a/ACT.SpecialSpellTimer/SpellTimerControl.xaml.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerControl.xaml.cs
@@ -251,8 +251,8 @@
                 this.RecastTimePanel.SetValue(Grid.ColumnProperty, 0);
                 this.RecastTimePanel.SetValue(HorizontalAlignmentProperty, HorizontalAlignment.Center);
                 this.RecastTimePanel.SetValue(VerticalAlignmentProperty, VerticalAlignment.Center);
-                this.RecastTimePanel.Width = this.SpellIconSize - 6;
-                this.RecastTimePanel.Height = this.SpellIconSize - 6;
+                this.RecastTimePanel.Width = this.SpellIconSize >= 6 ? this.SpellIconSize - 6 : double.NaN;
+                this.RecastTimePanel.Height = this.RecastTimePanel.Width;
             }
             else
             {


### PR DESCRIPTION
`FrameworkElement` の `Width` および `Height` プロパティの値の範囲は０.0以上である必要があるため、アイコンサイズを6未満に設定した場合に`ArgumentException`が発生する問題がありました。
アイコンサイズを6未満に設定した場合は、Width/Heightの規定値である `NaN` を設定するように修正を行いました。