### PR TITLE
fix NRE

### DIFF
--- a/ACT.SpecialSpellTimer/FF14PluginHelper.cs
+++ b/ACT.SpecialSpellTimer/FF14PluginHelper.cs
@@ -251,6 +251,11 @@
             }
 
             var currentZoneName = ActGlobals.oFormActMain.CurrentZone;
+            if (currentZoneName == null)
+            {
+                return 0;
+            }
+
             return (
                 from x in zoneList
                 where


### PR DESCRIPTION
再現条件を確認していないのですが `ActGlobals.oFormActMain.CurrentZone` が `null` のケースがあるようで、下記例外が発生したため、 `null` チェックを追加しました。

```
[2016/05/31 21:28:15.699] ACT.SpecialSpellTimer スペルタイマWindowのRefreshで例外が発生しました。
System.NullReferenceException: オブジェクト参照がオブジェクト インスタンスに設定されていません。
   場所 ACT.SpecialSpellTimer.FF14PluginHelper.<>c.<GetZoneList>b__11_0(Zone x)
   場所 System.Linq.EnumerableSorter`2.ComputeKeys(TElement[] elements, Int32 count)
   場所 System.Linq.EnumerableSorter`1.Sort(TElement[] elements, Int32 count)
   場所 System.Linq.OrderedEnumerable`1.<GetEnumerator>d__1.MoveNext()
   場所 System.Linq.Buffer`1..ctor(IEnumerable`1 source)
   場所 System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
   場所 ACT.SpecialSpellTimer.FF14PluginHelper.GetCurrentZoneID()
   場所 ACT.SpecialSpellTimer.SpellTimerTable.get_EnabledTableCore()
   場所 ACT.SpecialSpellTimer.SpellTimerTable.get_EnabledTable()
   場所 ACT.SpecialSpellTimer.SpellTimerCore.RefreshWindowTimerOnTick(Object sender, EventArgs e)
```
