### PR TITLE
suppress Win32Exception log

### DIFF
--- a/ACT.SpecialSpellTimer/SpellTimerCore.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerCore.cs
@@ -1287,6 +1287,10 @@
                     }
                 }
             }
+            catch (System.ComponentModel.Win32Exception)
+            {
+                // ignore
+            }
             catch (Exception ex)
             {
                 Logger.Write(Translate.Get("WatchActiveError"), ex);


### PR DESCRIPTION
下記エラーメッセージが記録されるのを抑制します。
フォアグラウンドアプリケーションが32bitアプリケーションだった場合にたまに発生していそうな感じです。
実害はないので、ロギング対象から除外するように変更しました。

```
[2016/06/02 00:24:31.832] ACT.SpecialSpellTimer フォアグラウンドWindowの監視で例外が発生しました。
System.ComponentModel.Win32Exception (0x80004005): プロセス モジュールを列挙できません。
   場所 System.Diagnostics.NtProcessManager.GetModuleInfos(Int32 processId, Boolean firstModuleOnly)
   場所 System.Diagnostics.NtProcessManager.GetFirstModuleInfo(Int32 processId)
   場所 System.Diagnostics.Process.get_MainModule()
   場所 ACT.SpecialSpellTimer.SpellTimerCore.IsActive()
```