### PR TITLE
画面の更新間隔を変更できる設定を追加しました

### DIFF
--- a/ACT.SpecialSpellTimer/ConfigPanel.Designer.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.Designer.cs
@@ -247,6 +247,10 @@
             this.label69 = new System.Windows.Forms.Label();
             this.label68 = new System.Windows.Forms.Label();
             this.OptionTabPage = new System.Windows.Forms.TabPage();
+            this.label90 = new System.Windows.Forms.Label();
+            this.label92 = new System.Windows.Forms.Label();
+            this.LogPollSleepNumericUpDown = new System.Windows.Forms.NumericUpDown();
+            this.label91 = new System.Windows.Forms.Label();
             this.HideWhenNotActiceCheckBox = new System.Windows.Forms.CheckBox();
             this.SaveLogButton = new System.Windows.Forms.Button();
             this.SaveLogCheckBox = new System.Windows.Forms.CheckBox();
@@ -332,6 +336,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.CombatLogBufferSizeNumericUpDown)).BeginInit();
             this.tabPage3.SuspendLayout();
             this.OptionTabPage.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.LogPollSleepNumericUpDown)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.RefreshIntervalNumericUpDown)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.TimeOfHideNumericUpDown)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.OpacityNumericUpDown)).BeginInit();
@@ -2129,26 +2134,26 @@
             this.toolStripSeparator2,
             this.CASetOriginItem});
             this.CombatAnalyzerContextMenuStrip.Name = "CombatAnalyzerContextMenuStrip";
-            this.CombatAnalyzerContextMenuStrip.Size = new System.Drawing.Size(224, 104);
+            this.CombatAnalyzerContextMenuStrip.Size = new System.Drawing.Size(245, 104);
             // 
             // CASelectAllItem
             // 
             this.CASelectAllItem.Name = "CASelectAllItem";
             this.CASelectAllItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.A)));
-            this.CASelectAllItem.Size = new System.Drawing.Size(223, 22);
+            this.CASelectAllItem.Size = new System.Drawing.Size(244, 22);
             this.CASelectAllItem.Text = "SelectAll";
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(220, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(241, 6);
             // 
             // CACopyLogItem
             // 
             this.CACopyLogItem.Name = "CACopyLogItem";
             this.CACopyLogItem.ShortcutKeyDisplayString = "";
             this.CACopyLogItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-            this.CACopyLogItem.Size = new System.Drawing.Size(223, 22);
+            this.CACopyLogItem.Size = new System.Drawing.Size(244, 22);
             this.CACopyLogItem.Text = "CopyLog";
             // 
             // CACopyLogDetailItem
@@ -2156,19 +2161,19 @@
             this.CACopyLogDetailItem.Name = "CACopyLogDetailItem";
             this.CACopyLogDetailItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.C)));
-            this.CACopyLogDetailItem.Size = new System.Drawing.Size(223, 22);
+            this.CACopyLogDetailItem.Size = new System.Drawing.Size(244, 22);
             this.CACopyLogDetailItem.Text = "CopyLogDetail";
             // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(220, 6);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(241, 6);
             // 
             // CASetOriginItem
             // 
             this.CASetOriginItem.Name = "CASetOriginItem";
             this.CASetOriginItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-            this.CASetOriginItem.Size = new System.Drawing.Size(223, 22);
+            this.CASetOriginItem.Size = new System.Drawing.Size(244, 22);
             this.CASetOriginItem.Text = "SetLogOrigin";
             // 
             // label6
@@ -2690,6 +2695,10 @@
             // OptionTabPage
             // 
             this.OptionTabPage.BackColor = System.Drawing.SystemColors.Control;
+            this.OptionTabPage.Controls.Add(this.label90);
+            this.OptionTabPage.Controls.Add(this.label92);
+            this.OptionTabPage.Controls.Add(this.LogPollSleepNumericUpDown);
+            this.OptionTabPage.Controls.Add(this.label91);
             this.OptionTabPage.Controls.Add(this.HideWhenNotActiceCheckBox);
             this.OptionTabPage.Controls.Add(this.SaveLogButton);
             this.OptionTabPage.Controls.Add(this.SaveLogCheckBox);
@@ -2741,6 +2750,57 @@
             this.OptionTabPage.TabIndex = 1;
             this.OptionTabPage.Text = "OptionTabPageTitle";
             // 
+            // label90
+            // 
+            this.label90.AutoSize = true;
+            this.label90.Location = new System.Drawing.Point(405, 330);
+            this.label90.Name = "label90";
+            this.label90.Size = new System.Drawing.Size(63, 12);
+            this.label90.TabIndex = 59;
+            this.label90.Text = "SpecsLabel";
+            // 
+            // label92
+            // 
+            this.label92.AutoSize = true;
+            this.label92.Location = new System.Drawing.Point(358, 330);
+            this.label92.Name = "label92";
+            this.label92.Size = new System.Drawing.Size(62, 12);
+            this.label92.TabIndex = 60;
+            this.label92.Text = "Millisecond";
+            // 
+            // LogPollSleepNumericUpDown
+            // 
+            this.LogPollSleepNumericUpDown.ImeMode = System.Windows.Forms.ImeMode.Disable;
+            this.LogPollSleepNumericUpDown.Location = new System.Drawing.Point(293, 328);
+            this.LogPollSleepNumericUpDown.Maximum = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            this.LogPollSleepNumericUpDown.Minimum = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.LogPollSleepNumericUpDown.Name = "LogPollSleepNumericUpDown";
+            this.LogPollSleepNumericUpDown.Size = new System.Drawing.Size(59, 19);
+            this.LogPollSleepNumericUpDown.TabIndex = 58;
+            this.LogPollSleepNumericUpDown.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            this.LogPollSleepNumericUpDown.Value = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            // 
+            // label91
+            // 
+            this.label91.AutoSize = true;
+            this.label91.Location = new System.Drawing.Point(6, 330);
+            this.label91.Name = "label91";
+            this.label91.Size = new System.Drawing.Size(138, 12);
+            this.label91.TabIndex = 57;
+            this.label91.Text = "LogPollSleepIntervalLabel";
+            // 
             // HideWhenNotActiceCheckBox
             // 
             this.HideWhenNotActiceCheckBox.AutoSize = true;
@@ -2754,7 +2814,7 @@
             // SaveLogButton
             // 
             this.SaveLogButton.Enabled = false;
-            this.SaveLogButton.Location = new System.Drawing.Point(605, 466);
+            this.SaveLogButton.Location = new System.Drawing.Point(605, 488);
             this.SaveLogButton.Name = "SaveLogButton";
             this.SaveLogButton.Size = new System.Drawing.Size(37, 25);
             this.SaveLogButton.TabIndex = 55;
@@ -2764,7 +2824,7 @@
             // SaveLogCheckBox
             // 
             this.SaveLogCheckBox.AutoSize = true;
-            this.SaveLogCheckBox.Location = new System.Drawing.Point(293, 447);
+            this.SaveLogCheckBox.Location = new System.Drawing.Point(293, 469);
             this.SaveLogCheckBox.Name = "SaveLogCheckBox";
             this.SaveLogCheckBox.Size = new System.Drawing.Size(64, 16);
             this.SaveLogCheckBox.TabIndex = 54;
@@ -2774,7 +2834,7 @@
             // SaveLogTextBox
             // 
             this.SaveLogTextBox.Enabled = false;
-            this.SaveLogTextBox.Location = new System.Drawing.Point(293, 469);
+            this.SaveLogTextBox.Location = new System.Drawing.Point(293, 491);
             this.SaveLogTextBox.Name = "SaveLogTextBox";
             this.SaveLogTextBox.Size = new System.Drawing.Size(306, 19);
             this.SaveLogTextBox.TabIndex = 53;
@@ -2782,7 +2842,7 @@
             // label67
             // 
             this.label67.AutoSize = true;
-            this.label67.Location = new System.Drawing.Point(6, 448);
+            this.label67.Location = new System.Drawing.Point(6, 470);
             this.label67.Name = "label67";
             this.label67.Size = new System.Drawing.Size(75, 12);
             this.label67.TabIndex = 52;
@@ -2790,7 +2850,7 @@
             // 
             // OverTextBox
             // 
-            this.OverTextBox.Location = new System.Drawing.Point(293, 422);
+            this.OverTextBox.Location = new System.Drawing.Point(293, 444);
             this.OverTextBox.Name = "OverTextBox";
             this.OverTextBox.Size = new System.Drawing.Size(100, 19);
             this.OverTextBox.TabIndex = 51;
@@ -2798,7 +2858,7 @@
             // label66
             // 
             this.label66.AutoSize = true;
-            this.label66.Location = new System.Drawing.Point(6, 425);
+            this.label66.Location = new System.Drawing.Point(6, 447);
             this.label66.Name = "label66";
             this.label66.Size = new System.Drawing.Size(79, 12);
             this.label66.TabIndex = 50;
@@ -2806,7 +2866,7 @@
             // 
             // ReadyTextBox
             // 
-            this.ReadyTextBox.Location = new System.Drawing.Point(293, 397);
+            this.ReadyTextBox.Location = new System.Drawing.Point(293, 419);
             this.ReadyTextBox.Name = "ReadyTextBox";
             this.ReadyTextBox.Size = new System.Drawing.Size(100, 19);
             this.ReadyTextBox.TabIndex = 49;
@@ -2814,7 +2874,7 @@
             // label65
             // 
             this.label65.AutoSize = true;
-            this.label65.Location = new System.Drawing.Point(6, 400);
+            this.label65.Location = new System.Drawing.Point(6, 422);
             this.label65.Name = "label65";
             this.label65.Size = new System.Drawing.Size(87, 12);
             this.label65.TabIndex = 48;
@@ -2823,7 +2883,7 @@
             // label64
             // 
             this.label64.AutoSize = true;
-            this.label64.Location = new System.Drawing.Point(357, 376);
+            this.label64.Location = new System.Drawing.Point(357, 398);
             this.label64.Name = "label64";
             this.label64.Size = new System.Drawing.Size(190, 12);
             this.label64.TabIndex = 47;
@@ -2832,7 +2892,7 @@
             // EnabledNotifyNormalSpellTimerCheckBox
             // 
             this.EnabledNotifyNormalSpellTimerCheckBox.AutoSize = true;
-            this.EnabledNotifyNormalSpellTimerCheckBox.Location = new System.Drawing.Point(293, 375);
+            this.EnabledNotifyNormalSpellTimerCheckBox.Location = new System.Drawing.Point(293, 397);
             this.EnabledNotifyNormalSpellTimerCheckBox.Name = "EnabledNotifyNormalSpellTimerCheckBox";
             this.EnabledNotifyNormalSpellTimerCheckBox.Size = new System.Drawing.Size(64, 16);
             this.EnabledNotifyNormalSpellTimerCheckBox.TabIndex = 46;
@@ -2842,7 +2902,7 @@
             // label63
             // 
             this.label63.AutoSize = true;
-            this.label63.Location = new System.Drawing.Point(6, 376);
+            this.label63.Location = new System.Drawing.Point(6, 398);
             this.label63.Name = "label63";
             this.label63.Size = new System.Drawing.Size(153, 12);
             this.label63.TabIndex = 45;
@@ -2851,7 +2911,7 @@
             // label49
             // 
             this.label49.AutoSize = true;
-            this.label49.Location = new System.Drawing.Point(357, 354);
+            this.label49.Location = new System.Drawing.Point(357, 376);
             this.label49.Name = "label49";
             this.label49.Size = new System.Drawing.Size(159, 12);
             this.label49.TabIndex = 44;
@@ -2860,7 +2920,7 @@
             // label31
             // 
             this.label31.AutoSize = true;
-            this.label31.Location = new System.Drawing.Point(6, 354);
+            this.label31.Location = new System.Drawing.Point(6, 376);
             this.label31.Name = "label31";
             this.label31.Size = new System.Drawing.Size(122, 12);
             this.label31.TabIndex = 43;
@@ -2869,7 +2929,7 @@
             // EnabledSpellTimerNoDecimalCheckBox
             // 
             this.EnabledSpellTimerNoDecimalCheckBox.AutoSize = true;
-            this.EnabledSpellTimerNoDecimalCheckBox.Location = new System.Drawing.Point(293, 353);
+            this.EnabledSpellTimerNoDecimalCheckBox.Location = new System.Drawing.Point(293, 375);
             this.EnabledSpellTimerNoDecimalCheckBox.Name = "EnabledSpellTimerNoDecimalCheckBox";
             this.EnabledSpellTimerNoDecimalCheckBox.Size = new System.Drawing.Size(64, 16);
             this.EnabledSpellTimerNoDecimalCheckBox.TabIndex = 42;
@@ -2919,7 +2979,7 @@
             // label48
             // 
             this.label48.AutoSize = true;
-            this.label48.Location = new System.Drawing.Point(357, 332);
+            this.label48.Location = new System.Drawing.Point(357, 354);
             this.label48.Name = "label48";
             this.label48.Size = new System.Drawing.Size(175, 12);
             this.label48.TabIndex = 32;
@@ -2928,7 +2988,7 @@
             // EnabledPTPlaceholderCheckBox
             // 
             this.EnabledPTPlaceholderCheckBox.AutoSize = true;
-            this.EnabledPTPlaceholderCheckBox.Location = new System.Drawing.Point(293, 331);
+            this.EnabledPTPlaceholderCheckBox.Location = new System.Drawing.Point(293, 353);
             this.EnabledPTPlaceholderCheckBox.Name = "EnabledPTPlaceholderCheckBox";
             this.EnabledPTPlaceholderCheckBox.Size = new System.Drawing.Size(64, 16);
             this.EnabledPTPlaceholderCheckBox.TabIndex = 31;
@@ -2938,7 +2998,7 @@
             // label43
             // 
             this.label43.AutoSize = true;
-            this.label43.Location = new System.Drawing.Point(6, 332);
+            this.label43.Location = new System.Drawing.Point(6, 354);
             this.label43.Name = "label43";
             this.label43.Size = new System.Drawing.Size(100, 12);
             this.label43.TabIndex = 30;
@@ -3270,6 +3330,7 @@
             this.tabPage3.PerformLayout();
             this.OptionTabPage.ResumeLayout(false);
             this.OptionTabPage.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.LogPollSleepNumericUpDown)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.RefreshIntervalNumericUpDown)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.TimeOfHideNumericUpDown)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.OpacityNumericUpDown)).EndInit();
@@ -3547,5 +3608,9 @@
         private System.Windows.Forms.TextBox SMNTextBox;
         private System.Windows.Forms.TextBox LogTextBox;
         private System.Windows.Forms.Label label89;
+        private System.Windows.Forms.Label label90;
+        private System.Windows.Forms.Label label92;
+        private System.Windows.Forms.NumericUpDown LogPollSleepNumericUpDown;
+        private System.Windows.Forms.Label label91;
     }
 }

--- a/ACT.SpecialSpellTimer/ConfigPanel.Option.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.Option.cs
@@ -185,6 +185,7 @@
             this.AutoSortReverseCheckBox.Checked = Settings.Default.AutoSortReverse;
             this.TimeOfHideNumericUpDown.Value = (decimal)Settings.Default.TimeOfHideSpell;
             this.RefreshIntervalNumericUpDown.Value = Settings.Default.RefreshInterval;
+            this.LogPollSleepNumericUpDown.Value = Settings.Default.LogPollSleepInterval;
             this.EnabledPTPlaceholderCheckBox.Checked = Settings.Default.EnabledPartyMemberPlaceholder;
             this.EnabledSpellTimerNoDecimalCheckBox.Checked = Settings.Default.EnabledSpellTimerNoDecimal;
             this.EnabledNotifyNormalSpellTimerCheckBox.Checked = Settings.Default.EnabledNotifyNormalSpellTimer;
@@ -221,6 +222,7 @@
             Settings.Default.AutoSortReverse = this.AutoSortReverseCheckBox.Checked;
             Settings.Default.TimeOfHideSpell = (double)this.TimeOfHideNumericUpDown.Value;
             Settings.Default.RefreshInterval = (long)this.RefreshIntervalNumericUpDown.Value;
+            Settings.Default.LogPollSleepInterval = (long)this.LogPollSleepNumericUpDown.Value;
             Settings.Default.EnabledPartyMemberPlaceholder = this.EnabledPTPlaceholderCheckBox.Checked;
             Settings.Default.EnabledSpellTimerNoDecimal = this.EnabledSpellTimerNoDecimalCheckBox.Checked;
 
@@ -229,6 +231,8 @@
 
             Settings.Default.SaveLogEnabled = this.SaveLogCheckBox.Checked;
             Settings.Default.SaveLogFile = this.SaveLogTextBox.Text;
+
+            SpellTimerCore.Default.InvalidateSettings();
 
             // 有効状態から無効状態に変化する場合は、標準のスペルタイマーから設定を削除する
             if (Settings.Default.EnabledNotifyNormalSpellTimer &&

--- a/ACT.SpecialSpellTimer/ConfigPanel.resx
+++ b/ACT.SpecialSpellTimer/ConfigPanel.resx
@@ -723,6 +723,18 @@
   <metadata name="OptionTabPage.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="label90.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="label92.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="LogPollSleepNumericUpDown.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="label91.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="HideWhenNotActiceCheckBox.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>

--- a/ACT.SpecialSpellTimer/Properties/Settings.Designer.cs
+++ b/ACT.SpecialSpellTimer/Properties/Settings.Designer.cs
@@ -406,5 +406,17 @@ namespace ACT.SpecialSpellTimer.Properties {
                 this["UpdateCheckInterval"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("100")]
+        public long LogPollSleepInterval {
+            get {
+                return ((long)(this["LogPollSleepInterval"]));
+            }
+            set {
+                this["LogPollSleepInterval"] = value;
+            }
+        }
     }
 }

--- a/ACT.SpecialSpellTimer/Properties/Settings.settings
+++ b/ACT.SpecialSpellTimer/Properties/Settings.settings
@@ -98,5 +98,8 @@
     <Setting Name="UpdateCheckInterval" Type="System.Double" Scope="User">
       <Value Profile="(Default)">12</Value>
     </Setting>
+    <Setting Name="LogPollSleepInterval" Type="System.Int64" Scope="User">
+      <Value Profile="(Default)">100</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/ACT.SpecialSpellTimer/app.config
+++ b/ACT.SpecialSpellTimer/app.config
@@ -103,6 +103,9 @@
       <setting name="UpdateCheckInterval" serializeAs="String">
         <value>12</value>
       </setting>
+      <setting name="LogPollSleepInterval" serializeAs="String">
+        <value>100</value>
+      </setting>
     </ACT.SpecialSpellTimer.Properties.Settings>
   </userSettings>
   <startup>

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-EN.Designer.cs
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-EN.Designer.cs
@@ -898,6 +898,15 @@ namespace ACT.SpecialSpellTimer.resources.strings {
         }
         
         /// <summary>
+        ///   Log poll sleep interval に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string LogPollSleepIntervalLabel {
+            get {
+                return ResourceManager.GetString("LogPollSleepIntervalLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Type に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string LogTypeHeader {

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-EN.resx
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-EN.resx
@@ -1045,4 +1045,8 @@
     <value>Monitor</value>
     <comment>モニター</comment>
   </data>
+  <data name="LogPollSleepIntervalLabel" xml:space="preserve">
+    <value>Log poll sleep interval</value>
+    <comment>ログ処理の最短間隔</comment>
+  </data>
 </root>

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-JP.Designer.cs
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-JP.Designer.cs
@@ -898,6 +898,15 @@ namespace ACT.SpecialSpellTimer.resources.strings {
         }
         
         /// <summary>
+        ///   ログ処理の最短間隔 に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string LogPollSleepIntervalLabel {
+            get {
+                return ResourceManager.GetString("LogPollSleepIntervalLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   種類 に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string LogTypeHeader {

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-JP.resx
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-JP.resx
@@ -1045,4 +1045,8 @@
     <value>モニター</value>
     <comment>Monitor</comment>
   </data>
+  <data name="LogPollSleepIntervalLabel" xml:space="preserve">
+    <value>ログ処理の最短間隔</value>
+    <comment>log poll sleep interval</comment>
+  </data>
 </root>


### PR DESCRIPTION
現在画面の更新間隔は100ms固定値となっていたので、ログ処理の間隔を設定できるUIを追加し、画面の更新間隔とログ処理の間隔を個別に変更できるようにしました。

![default](https://cloud.githubusercontent.com/assets/2145323/15729113/4e22e9a8-289c-11e6-87c4-6b5947f4fe6e.PNG)

ちょっとラベル名がいまいちな気もしますが、こんなんで大丈夫でしょうか。 

ポーリングのスリープ間隔とした意図は、今後行おうとしてるパフォーマンス向上の修正で、溜めているログが残っている間はスリープせず、ログが全部捌けたらポーリングをしばらく止める、という感じに変更しようかと思って、先行してこんな名前にしちゃってます。

resolves #43 