### PR TITLE
fix missing null check

### DIFF
--- a/ACT.SpecialSpellTimer/SpellTimerTable.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerTable.cs
@@ -554,6 +554,11 @@
         public static void Save(
             string file)
         {
+            if (table == null)
+            {
+                return;
+            }
+
             var dir = Path.GetDirectoryName(file);
             if (!Directory.Exists(dir))
             {


### PR DESCRIPTION
レアケースだと思いますが、プラグインの有効無効切り替えのチェックボックスを連打したりして、有効のあと即無効になった場合に、`table` フィールドに値が入る前に `Save` メソッドが呼び出されると、続く以下の部分でLINQ関連の例外が発生して落ちる事があったため、`null` チェックを追加しました。

```
var work = new List<SpellTimer>(table.Where(x => !x.IsInstance));
```

そんなことするなよって感じですが、有効にしたけどやっぱなし、みたいな事やった場合に起きるかもしれないので、保険的な…。

ACT本体のログ
```
***** 2016-06-01T08:11:57 - ACT.SpecialSpellTimer プラグインの終了で例外が発生しました。
System.ArgumentNullException: 値を Null にすることはできません。
パラメーター名:source
   場所 System.Linq.Enumerable.Where[TSource](IEnumerable`1 source, Func`2 predicate)
   場所 ACT.SpecialSpellTimer.SpellTimerTable.Save(String file)
   場所 ACT.SpecialSpellTimer.SpellTimerCore.End()
   場所 ACT.SpecialSpellTimer.SpecialSpellTimerPlugin.Advanced_Combat_Tracker.IActPluginV1.DeInitPlugin()
   場所 Advanced_Combat_Tracker.FormActMain.WriteExceptionLog(Exception ex, String MoreInfo)
   場所 ACT.SpecialSpellTimer.SpecialSpellTimerPlugin.Advanced_Combat_Tracker.IActPluginV1.DeInitPlugin()
   場所 Advanced_Combat_Tracker.FormActMain.pluginPanelEnabledChecked(Object sender, EventArgs e)
   場所 System.Windows.Forms.CheckBox.OnCheckedChanged(EventArgs e)
   場所 System.Windows.Forms.CheckBox.set_CheckState(CheckState value)
   場所 System.Windows.Forms.CheckBox.OnClick(EventArgs e)
   場所 System.Windows.Forms.CheckBox.OnMouseUp(MouseEventArgs mevent)
   場所 System.Windows.Forms.Control.WmMouseUp(Message& m, MouseButtons button, Int32 clicks)
   場所 System.Windows.Forms.Control.WndProc(Message& m)
   場所 System.Windows.Forms.ButtonBase.WndProc(Message& m)
   場所 System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
   場所 System.Windows.Forms.UnsafeNativeMethods.DispatchMessageW(MSG& msg)
   場所 System.Windows.Forms.UnsafeNativeMethods.DispatchMessageW(MSG& msg)
   場所 System.Windows.Forms.Application.ComponentManager.System.Windows.Forms.UnsafeNativeMethods.IMsoComponentManager.FPushMessageLoop(IntPtr dwComponentID, Int32 reason, Int32 pvLoopData)
   場所 System.Windows.Forms.Application.ThreadContext.RunMessageLoopInner(Int32 reason, ApplicationContext context)
   場所 System.Windows.Forms.Application.ThreadContext.RunMessageLoop(Int32 reason, ApplicationContext context)
   場所 Advanced_Combat_Tracker.ActLoader.Main(String[] args)
```