### PR TITLE
[wip]パフォーマンス改善

### DIFF
--- a/ACT.SpecialSpellTimer/CombatAnalyzer.cs
+++ b/ACT.SpecialSpellTimer/CombatAnalyzer.cs
@@ -196,7 +196,7 @@
             {
                 // プレイヤ情報とパーティリストを取得する
                 var player = FF14PluginHelper.GetPlayer();
-                var ptlist = LogBuffer.GetPTMember();
+                var ptlist = LogBuffer.PartyList;
 
                 if (player == null ||
                     ptlist == null)

--- a/ACT.SpecialSpellTimer/ConfigPanel.Monitor.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.Monitor.cs
@@ -37,13 +37,7 @@
             }
         }
 
-        public bool MonitorTabSelected
-        {
-            get
-            {
-                return this.TabControl.SelectedTab == this.tabPage3;
-            }
-        }
+        private bool MonitorTabSelected => this.TabControl.SelectedTab == this.tabPage3;
 
         /// <summary>
         /// ログを追加する
@@ -63,8 +57,16 @@
 
         public void UpdateMonitor()
         {
-            if (Interlocked.CompareExchange(ref placeholderIsValid, VALID, INVALID) != INVALID)
+            if (!MonitorTabSelected)
+            {
+                InvalidatePlaceholders();
                 return;
+            }
+
+            if (Interlocked.CompareExchange(ref placeholderIsValid, VALID, INVALID) != INVALID)
+            {
+                return;
+            }
 
             var player = FF14PluginHelper.GetPlayer();
             RefreshPlaceholders(

--- a/ACT.SpecialSpellTimer/ConfigPanel.Monitor.cs
+++ b/ACT.SpecialSpellTimer/ConfigPanel.Monitor.cs
@@ -11,8 +11,8 @@
     public partial class ConfigPanel
     {
         private string playerName;
-        private List<string> partyMemberNames;
-        private List<KeyValuePair<string, string>> jobPlaceholders;
+        private IReadOnlyList<string> partyMemberNames;
+        private IReadOnlyDictionary<string, string> jobPlaceholders;
         private StringBuilder logBuffer = new StringBuilder();
 
         /// <summary>
@@ -51,8 +51,8 @@
         /// <param name="jobPlaceholders">ジョブ名プレースホルダのリスト</param>
         public void RefreshPlaceholders(
             string playerName,
-            List<string> partyMemberNames,
-            List< KeyValuePair<string, string>> jobPlaceholders)
+            IReadOnlyList<string> partyMemberNames,
+            IReadOnlyDictionary<string, string> jobPlaceholders)
         {
             // 一旦クリアする
             this.MeTextBox.Clear();

--- a/ACT.SpecialSpellTimer/FF14PluginHelper.cs
+++ b/ACT.SpecialSpellTimer/FF14PluginHelper.cs
@@ -279,6 +279,11 @@
         public int CurrentMP;
         public int MaxMP;
         public int CurrentTP;
+
+        public SpecialSpellTimer.Job AsJob()
+        {
+            return SpecialSpellTimer.Job.FromId(Job);
+        }
     }
 
     public class Zone

--- a/ACT.SpecialSpellTimer/FF14PluginHelper.cs
+++ b/ACT.SpecialSpellTimer/FF14PluginHelper.cs
@@ -15,7 +15,7 @@
         private static object pluginMemory;
         private static dynamic pluginConfig;
         private static dynamic pluginScancombat;
-        private static List<Zone> zoneList;
+        private static volatile IReadOnlyList<Zone> zoneList;
 
         public static void Initialize()
         {
@@ -176,22 +176,22 @@
             return partyList;
         }
 
-        public static Zone[] GetZoneList()
+        public static IReadOnlyList<Zone> GetZoneList()
         {
-            if (zoneList != null &&
-                zoneList.Count() > 0)
+            var list = zoneList;
+            if (list != null && list.Count() > 0)
             {
-                return zoneList.OrderBy(x => x.ID).ToArray();
+                return list;
             }
-
-            zoneList = new List<Zone>();
 
             Initialize();
 
             if (plugin == null)
             {
-                return zoneList.OrderBy(x => x.ID).ToArray();
+                return Enumerable.Empty<Zone>().ToList();
             }
+
+            var newList = new List<Zone>();
 
             var asm = plugin.GetType().Assembly;
 
@@ -206,7 +206,7 @@
                         var values = line.Split('|');
                         if (values.Length >= 2)
                         {
-                            zoneList.Add(new Zone()
+                            newList.Add(new Zone()
                             {
                                 ID = int.Parse(values[0]),
                                 Name = values[1].Trim()
@@ -227,7 +227,7 @@
                         var values = line.Split('|');
                         if (values.Length >= 2)
                         {
-                            zoneList.Add(new Zone()
+                            newList.Add(new Zone()
                             {
                                 ID = int.Parse(values[0]),
                                 Name = values[1].Trim()
@@ -237,31 +237,29 @@
                 }
             }
 
-            return zoneList.OrderBy(x => x.ID).ToArray();
+            newList = newList.OrderBy(x => x.ID).ToList();
+            zoneList = newList;
+            return newList;
         }
 
         public static int GetCurrentZoneID()
         {
+            var currentZoneName = ActGlobals.oFormActMain.CurrentZone;
+            if (string.IsNullOrEmpty(currentZoneName) || currentZoneName == "Unknown Zone")
+            {
+                return 0;
+            }
+
             var zoneList = GetZoneList();
 
-            if (zoneList == null ||
-                zoneList.Length < 1)
+            if (zoneList == null || zoneList.Count < 1)
             {
                 return 0;
             }
 
-            var currentZoneName = ActGlobals.oFormActMain.CurrentZone;
-            if (currentZoneName == null)
-            {
-                return 0;
-            }
-
-            return (
-                from x in zoneList
-                where
-                x.Name.ToLower() == currentZoneName.ToLower()
-                select
-                x.ID).FirstOrDefault();
+            var foundZone = zoneList.AsParallel().FirstOrDefault(zone =>
+                string.Equals(zone.Name, currentZoneName, System.StringComparison.OrdinalIgnoreCase));
+            return foundZone != null ? foundZone.ID : 0;
         }
     }
 

--- a/ACT.SpecialSpellTimer/Job.cs
+++ b/ACT.SpecialSpellTimer/Job.cs
@@ -1,6 +1,7 @@
 ﻿namespace ACT.SpecialSpellTimer
 {
     using System.Collections.Generic;
+    using System.Linq;
 
     /// <summary>
     /// ジョブ
@@ -10,95 +11,72 @@
         /// <summary>
         /// ジョブリスト
         /// </summary>
-        private static readonly IReadOnlyList<Job> _jobList;
+        private static readonly IReadOnlyList<Job> _jobList = new List<Job> {
+            new Job(JobIds.GLD, JobRoles.Tank),
+            new Job(JobIds.PUG, JobRoles.MeleeDPS),
+            new Job(JobIds.MRD, JobRoles.Tank),
+            new Job(JobIds.LNC, JobRoles.MeleeDPS),
+            new Job(JobIds.ARC, JobRoles.RangerDPS),
+            new Job(JobIds.CNJ, JobRoles.Healer),
+            new Job(JobIds.THM, JobRoles.CasterDPS),
+            new Job(JobIds.CRP, JobRoles.Crafter),
+            new Job(JobIds.BSM, JobRoles.Crafter),
+            new Job(JobIds.ARM, JobRoles.Crafter),
+            new Job(JobIds.GSM, JobRoles.Crafter),
+            new Job(JobIds.LTW, JobRoles.Crafter),
+            new Job(JobIds.WVR, JobRoles.Crafter),
+            new Job(JobIds.ALC, JobRoles.Crafter),
+            new Job(JobIds.CUL, JobRoles.Crafter),
+            new Job(JobIds.MIN, JobRoles.Gatherer),
+            new Job(JobIds.BOT, JobRoles.Gatherer),
+            new Job(JobIds.FSH, JobRoles.Gatherer),
+            new Job(JobIds.PLD, JobRoles.Tank),
+            new Job(JobIds.MNK, JobRoles.MeleeDPS),
+            new Job(JobIds.WAR, JobRoles.Tank),
+            new Job(JobIds.DRG, JobRoles.MeleeDPS),
+            new Job(JobIds.BRD, JobRoles.RangerDPS),
+            new Job(JobIds.WHM, JobRoles.Healer),
+            new Job(JobIds.BLM, JobRoles.CasterDPS),
+            new Job(JobIds.ACN, JobRoles.CasterDPS),
+            new Job(JobIds.SMN, JobRoles.CasterDPS),
+            new Job(JobIds.SCH, JobRoles.Healer),
+            new Job(JobIds.ROG, JobRoles.MeleeDPS),
+            new Job(JobIds.NIN, JobRoles.MeleeDPS),
+            new Job(JobIds.MCH, JobRoles.RangerDPS),
+            new Job(JobIds.DRK, JobRoles.Tank),
+            new Job(JobIds.AST, JobRoles.Healer),
+        };
 
         /// <summary>
         /// ジョブ辞書
         /// </summary>
-        private static readonly IReadOnlyDictionary<int, Job> _jobDictionary;
-
-        /// <summary>
-        /// JobId
-        /// </summary>
-        public int JobId { get; private set; }
-
-        /// <summary>
-        /// JobName
-        /// </summary>
-        public string JobName { get; private set; }
-
-        /// <summary>
-        /// ロール
-        /// </summary>
-        public JobRoles Role { get; private set; }
-
-        static Job()
-        {
-            var list = new List<Job>();
-            list.Add(new Job(JobIds.GLD, JobRoles.Tank));
-            list.Add(new Job(JobIds.PUG, JobRoles.MeleeDPS));
-            list.Add(new Job(JobIds.MRD, JobRoles.Tank));
-            list.Add(new Job(JobIds.LNC, JobRoles.MeleeDPS));
-            list.Add(new Job(JobIds.ARC, JobRoles.RangerDPS));
-            list.Add(new Job(JobIds.CNJ, JobRoles.Healer));
-            list.Add(new Job(JobIds.THM, JobRoles.CasterDPS));
-            list.Add(new Job(JobIds.CRP, JobRoles.Crafter));
-            list.Add(new Job(JobIds.BSM, JobRoles.Crafter));
-            list.Add(new Job(JobIds.ARM, JobRoles.Crafter));
-            list.Add(new Job(JobIds.GSM, JobRoles.Crafter));
-            list.Add(new Job(JobIds.LTW, JobRoles.Crafter));
-            list.Add(new Job(JobIds.WVR, JobRoles.Crafter));
-            list.Add(new Job(JobIds.ALC, JobRoles.Crafter));
-            list.Add(new Job(JobIds.CUL, JobRoles.Crafter));
-            list.Add(new Job(JobIds.MIN, JobRoles.Gatherer));
-            list.Add(new Job(JobIds.BOT, JobRoles.Gatherer));
-            list.Add(new Job(JobIds.FSH, JobRoles.Gatherer));
-            list.Add(new Job(JobIds.PLD, JobRoles.Tank));
-            list.Add(new Job(JobIds.MNK, JobRoles.MeleeDPS));
-            list.Add(new Job(JobIds.WAR, JobRoles.Tank));
-            list.Add(new Job(JobIds.DRG, JobRoles.MeleeDPS));
-            list.Add(new Job(JobIds.BRD, JobRoles.RangerDPS));
-            list.Add(new Job(JobIds.WHM, JobRoles.Healer));
-            list.Add(new Job(JobIds.BLM, JobRoles.CasterDPS));
-            list.Add(new Job(JobIds.ACN, JobRoles.CasterDPS));
-            list.Add(new Job(JobIds.SMN, JobRoles.CasterDPS));
-            list.Add(new Job(JobIds.SCH, JobRoles.Healer));
-            list.Add(new Job(JobIds.ROG, JobRoles.MeleeDPS));
-            list.Add(new Job(JobIds.NIN, JobRoles.MeleeDPS));
-            list.Add(new Job(JobIds.MCH, JobRoles.RangerDPS));
-            list.Add(new Job(JobIds.DRK, JobRoles.Tank));
-            list.Add(new Job(JobIds.AST, JobRoles.Healer));
-            _jobList = list;
-
-            var dict = new Dictionary<int, Job>();
-            foreach (var job in JobList)
-            {
-                dict.Add(job.JobId, job);
-            }
-            _jobDictionary = dict;
-        }
+        private static readonly IReadOnlyDictionary<int, Job> _jobDictionary =
+            _jobList.ToDictionary(job => job.JobId, job => job);
 
         /// <summary>
         /// ジョブの一覧
         /// </summary>
-        public static IReadOnlyList<Job> JobList
-        {
-            get
-            {
-                return _jobList;
-            }
-        }
+        public static IReadOnlyList<Job> JobList => _jobList;
 
         /// <summary>
         /// ジョブIDをキーに持つ辞書
         /// </summary>
-        public static IReadOnlyDictionary<int, Job> JobDictionary
-        {
-            get
-            {
-                return _jobDictionary;
-            }
-        }
+        public static IReadOnlyDictionary<int, Job> JobDictionary => _jobDictionary;
+
+        /// <summary>
+        /// JobId
+        /// </summary>
+        public int JobId { get; }
+
+        /// <summary>
+        /// JobName
+        /// </summary>
+        public string JobName { get; }
+
+        /// <summary>
+        /// ロール
+        /// </summary>
+        public JobRoles Role { get; }
 
         public static Job FromId(int jobId)
         {
@@ -110,8 +88,7 @@
         /// </summary>
         /// <param name="jobID">ジョブID</param>
         /// <returns>ジョブ名</returns>
-        public static string GetJobName(
-            int jobID)
+        public static string GetJobName(int jobID)
         {
             if (JobDictionary.ContainsKey(jobID))
             {

--- a/ACT.SpecialSpellTimer/Job.cs
+++ b/ACT.SpecialSpellTimer/Job.cs
@@ -10,77 +10,99 @@
         /// <summary>
         /// ジョブリスト
         /// </summary>
-        private static Job[] jobList;
+        private static readonly IReadOnlyList<Job> _jobList;
 
         /// <summary>
         /// ジョブ辞書
         /// </summary>
-        private static Dictionary<int, Job> jobDictinary;
+        private static readonly IReadOnlyDictionary<int, Job> _jobDictionary;
 
         /// <summary>
         /// JobId
         /// </summary>
-        public int JobId { get; set; }
+        public int JobId { get; private set; }
 
         /// <summary>
         /// JobName
         /// </summary>
-        public string JobName { get; set; }
+        public string JobName { get; private set; }
 
         /// <summary>
         /// ロール
         /// </summary>
-        public JobRoles Role { get; set; }
+        public JobRoles Role { get; private set; }
+
+        static Job()
+        {
+            var list = new List<Job>();
+            list.Add(new Job(JobIds.GLD, JobRoles.Tank));
+            list.Add(new Job(JobIds.PUG, JobRoles.MeleeDPS));
+            list.Add(new Job(JobIds.MRD, JobRoles.Tank));
+            list.Add(new Job(JobIds.LNC, JobRoles.MeleeDPS));
+            list.Add(new Job(JobIds.ARC, JobRoles.RangerDPS));
+            list.Add(new Job(JobIds.CNJ, JobRoles.Healer));
+            list.Add(new Job(JobIds.THM, JobRoles.CasterDPS));
+            list.Add(new Job(JobIds.CRP, JobRoles.Crafter));
+            list.Add(new Job(JobIds.BSM, JobRoles.Crafter));
+            list.Add(new Job(JobIds.ARM, JobRoles.Crafter));
+            list.Add(new Job(JobIds.GSM, JobRoles.Crafter));
+            list.Add(new Job(JobIds.LTW, JobRoles.Crafter));
+            list.Add(new Job(JobIds.WVR, JobRoles.Crafter));
+            list.Add(new Job(JobIds.ALC, JobRoles.Crafter));
+            list.Add(new Job(JobIds.CUL, JobRoles.Crafter));
+            list.Add(new Job(JobIds.MIN, JobRoles.Gatherer));
+            list.Add(new Job(JobIds.BOT, JobRoles.Gatherer));
+            list.Add(new Job(JobIds.FSH, JobRoles.Gatherer));
+            list.Add(new Job(JobIds.PLD, JobRoles.Tank));
+            list.Add(new Job(JobIds.MNK, JobRoles.MeleeDPS));
+            list.Add(new Job(JobIds.WAR, JobRoles.Tank));
+            list.Add(new Job(JobIds.DRG, JobRoles.MeleeDPS));
+            list.Add(new Job(JobIds.BRD, JobRoles.RangerDPS));
+            list.Add(new Job(JobIds.WHM, JobRoles.Healer));
+            list.Add(new Job(JobIds.BLM, JobRoles.CasterDPS));
+            list.Add(new Job(JobIds.ACN, JobRoles.CasterDPS));
+            list.Add(new Job(JobIds.SMN, JobRoles.CasterDPS));
+            list.Add(new Job(JobIds.SCH, JobRoles.Healer));
+            list.Add(new Job(JobIds.ROG, JobRoles.MeleeDPS));
+            list.Add(new Job(JobIds.NIN, JobRoles.MeleeDPS));
+            list.Add(new Job(JobIds.MCH, JobRoles.RangerDPS));
+            list.Add(new Job(JobIds.DRK, JobRoles.Tank));
+            list.Add(new Job(JobIds.AST, JobRoles.Healer));
+            _jobList = list;
+
+            var dict = new Dictionary<int, Job>();
+            foreach (var job in JobList)
+            {
+                dict.Add(job.JobId, job);
+            }
+            _jobDictionary = dict;
+        }
 
         /// <summary>
-        /// ジョブリストを取得する
+        /// ジョブの一覧
         /// </summary>
-        /// <returns>
-        /// ジョブリスト</returns>
-        public static Job[] GetJobList()
+        public static IReadOnlyList<Job> JobList
         {
-            if (jobList == null)
+            get
             {
-                var list = new List<Job>();
-
-                list.Add(new Job() { JobId = 1, JobName = "GLD", Role = JobRoles.Tank });
-                list.Add(new Job() { JobId = 2, JobName = "PUG", Role = JobRoles.MeleeDPS });
-                list.Add(new Job() { JobId = 3, JobName = "MRD", Role = JobRoles.Tank });
-                list.Add(new Job() { JobId = 4, JobName = "LNC", Role = JobRoles.MeleeDPS });
-                list.Add(new Job() { JobId = 5, JobName = "ARC", Role = JobRoles.RangerDPS });
-                list.Add(new Job() { JobId = 6, JobName = "CNJ", Role = JobRoles.Healer });
-                list.Add(new Job() { JobId = 7, JobName = "THM", Role = JobRoles.CasterDPS });
-                list.Add(new Job() { JobId = 8, JobName = "CRP", Role = JobRoles.Crafter });
-                list.Add(new Job() { JobId = 9, JobName = "BSM", Role = JobRoles.Crafter });
-                list.Add(new Job() { JobId = 10, JobName = "ARM", Role = JobRoles.Crafter });
-                list.Add(new Job() { JobId = 11, JobName = "GSM", Role = JobRoles.Crafter });
-                list.Add(new Job() { JobId = 12, JobName = "LTW", Role = JobRoles.Crafter });
-                list.Add(new Job() { JobId = 13, JobName = "WVR", Role = JobRoles.Crafter });
-                list.Add(new Job() { JobId = 14, JobName = "ALC", Role = JobRoles.Crafter });
-                list.Add(new Job() { JobId = 15, JobName = "CUL", Role = JobRoles.Crafter });
-                list.Add(new Job() { JobId = 16, JobName = "MIN", Role = JobRoles.Gatherer });
-                list.Add(new Job() { JobId = 17, JobName = "BOT", Role = JobRoles.Gatherer });
-                list.Add(new Job() { JobId = 18, JobName = "FSH", Role = JobRoles.Gatherer });
-                list.Add(new Job() { JobId = 19, JobName = "PLD", Role = JobRoles.Tank });
-                list.Add(new Job() { JobId = 20, JobName = "MNK", Role = JobRoles.MeleeDPS });
-                list.Add(new Job() { JobId = 21, JobName = "WAR", Role = JobRoles.Tank });
-                list.Add(new Job() { JobId = 22, JobName = "DRG", Role = JobRoles.MeleeDPS });
-                list.Add(new Job() { JobId = 23, JobName = "BRD", Role = JobRoles.RangerDPS });
-                list.Add(new Job() { JobId = 24, JobName = "WHM", Role = JobRoles.Healer });
-                list.Add(new Job() { JobId = 25, JobName = "BLM", Role = JobRoles.CasterDPS });
-                list.Add(new Job() { JobId = 26, JobName = "ACN", Role = JobRoles.CasterDPS });
-                list.Add(new Job() { JobId = 27, JobName = "SMN", Role = JobRoles.CasterDPS });
-                list.Add(new Job() { JobId = 28, JobName = "SCH", Role = JobRoles.Healer });
-                list.Add(new Job() { JobId = 29, JobName = "ROG", Role = JobRoles.MeleeDPS });
-                list.Add(new Job() { JobId = 30, JobName = "NIN", Role = JobRoles.MeleeDPS });
-                list.Add(new Job() { JobId = 31, JobName = "MCH", Role = JobRoles.RangerDPS });
-                list.Add(new Job() { JobId = 32, JobName = "DRK", Role = JobRoles.Tank });
-                list.Add(new Job() { JobId = 33, JobName = "AST", Role = JobRoles.Healer });
-
-                jobList = list.ToArray();
+                return _jobList;
             }
+        }
 
-            return jobList;
+        /// <summary>
+        /// ジョブIDをキーに持つ辞書
+        /// </summary>
+        public static IReadOnlyDictionary<int, Job> JobDictionary
+        {
+            get
+            {
+                return _jobDictionary;
+            }
+        }
+
+        public static Job FromId(int jobId)
+        {
+            return JobDictionary[jobId];
         }
 
         /// <summary>
@@ -91,23 +113,29 @@
         public static string GetJobName(
             int jobID)
         {
-            if (jobDictinary == null)
+            if (JobDictionary.ContainsKey(jobID))
             {
-                jobDictinary = new Dictionary<int, Job>();
-                foreach (var job in GetJobList())
-                {
-                    jobDictinary.Add(job.JobId, job);
-                }
-            }
-
-            if (jobDictinary.ContainsKey(jobID))
-            {
-                return jobDictinary[jobID].JobName;
+                return JobDictionary[jobID].JobName;
             }
             else
             {
                 return string.Empty;
             }
+        }
+
+        private Job(JobIds id, JobRoles role)
+        {
+            this.JobId = (int)id;
+            this.JobName = System.Enum.GetName(typeof(JobIds), id);
+            this.Role = role;
+        }
+
+        public bool IsSummoner()
+        {
+            const int ARC = (int)JobIds.ARC;
+            const int SCH = (int)JobIds.SCH;
+            const int SMN = (int)JobIds.SMN;
+            return JobId == ARC || JobId == SCH || JobId == SMN;
         }
 
         /// <summary>
@@ -130,5 +158,42 @@
         CasterDPS = 33,
         Crafter = 40,
         Gatherer = 50,
+    }
+
+    public enum JobIds
+    {
+        GLD = 1,
+        PUG = 2,
+        MRD = 3,
+        LNC = 4,
+        ARC = 5,
+        CNJ = 6,
+        THM = 7,
+        CRP = 8,
+        BSM = 9,
+        ARM = 10,
+        GSM = 11,
+        LTW = 12,
+        WVR = 13,
+        ALC = 14,
+        CUL = 15,
+        MIN = 16,
+        BOT = 17,
+        FSH = 18,
+        PLD = 19,
+        MNK = 20,
+        WAR = 21,
+        DRG = 22,
+        BRD = 23,
+        WHM = 24,
+        BLM = 25,
+        ACN = 26,
+        SMN = 27,
+        SCH = 28,
+        ROG = 29,
+        NIN = 30,
+        MCH = 31,
+        DRK = 32,
+        AST = 33,
     }
 }

--- a/ACT.SpecialSpellTimer/LogBuffer.cs
+++ b/ACT.SpecialSpellTimer/LogBuffer.cs
@@ -165,6 +165,11 @@
             GC.SuppressFinalize(this);
         }
 
+        public bool nonEmpty()
+        {
+            return !logInfoQueue.IsEmpty;
+        }
+
         /// <summary>
         /// ログ行を返す
         /// </summary>
@@ -172,10 +177,7 @@
         /// ログ行の配列</returns>
         public IReadOnlyList<string> GetLogLines()
         {
-            lock (this.logInfoQueue)
-            {
-                return OnLogLineRead();
-            }
+            return OnLogLineRead();
         }
 
         /// <summary>

--- a/ACT.SpecialSpellTimer/LogBuffer.cs
+++ b/ACT.SpecialSpellTimer/LogBuffer.cs
@@ -234,9 +234,7 @@
 #if DEBUG
                 Debug.WriteLine("JOB NAME!! " + jobName);
 #endif
-                if (jobName == "巴術士" || jobName == "ARC" ||
-                    jobName == "学者" || jobName == "SCH" ||
-                    jobName == "召喚士" || jobName == "SMN")
+                if (player.AsJob().IsSummoner())
                 {
                     if (logLine.Contains(player.Name + "の「サモン") ||
                         logLine.Contains("You cast Summon"))
@@ -407,7 +405,7 @@
                 // FF14内部のPTメンバ自動ソート順で並び替える
                 var sorted =
                     from x in combatants
-                    join y in Job.GetJobList() on
+                    join y in Job.JobList on
                         x.Job equals y.JobId
                     where
                     x.ID != player.ID
@@ -433,7 +431,7 @@
                 }
 
                 // ジョブ名によるプレースホルダを登録する
-                foreach (var job in Job.GetJobList())
+                foreach (var job in Job.JobList)
                 {
                     // このジョブに該当するパーティメンバを抽出する
                     var combatantsByJob = (

--- a/ACT.SpecialSpellTimer/LogBuffer.cs
+++ b/ACT.SpecialSpellTimer/LogBuffer.cs
@@ -586,11 +586,8 @@
             // スペルタイマーの再描画を行う
             SpellTimerTable.ClearUpdateFlags();
 
-            // モニタタブに出力する
-            SpecialSpellTimerPlugin.ConfigPanel.RefreshPlaceholders(
-                player.Name,
-                PartyList,
-                PlaceholderToJobNameDictionaly);
+            // モニタタブの情報を無効にする
+            SpecialSpellTimerPlugin.ConfigPanel.InvalidatePlaceholders();
         }
 
         /// <summary>

--- a/ACT.SpecialSpellTimer/OnePointTelopController.cs
+++ b/ACT.SpecialSpellTimer/OnePointTelopController.cs
@@ -191,7 +191,7 @@
         /// <param name="logLines">ログ行</param>
         public static void Match(
             OnePointTelop[] telops,
-            string[] logLines)
+            IReadOnlyList<string> logLines)
         {
             foreach (var log in logLines)
             {

--- a/ACT.SpecialSpellTimer/OnePointTelopController.cs
+++ b/ACT.SpecialSpellTimer/OnePointTelopController.cs
@@ -159,7 +159,7 @@
         /// </summary>
         /// <param name="telops">Telops</param>
         public static void GarbageWindows(
-            OnePointTelop[] telops)
+            IReadOnlyList<OnePointTelop> telops)
         {
             // 不要になったWindowを閉じる
             var removeWindowList = new List<OnePointTelopWindow>();
@@ -190,7 +190,7 @@
         /// <param name="telops">Telops</param>
         /// <param name="logLines">ログ行</param>
         public static void Match(
-            OnePointTelop[] telops,
+            IReadOnlyList<OnePointTelop> telops,
             IReadOnlyList<string> logLines)
         {
             foreach (var log in logLines)
@@ -349,7 +349,7 @@
         /// </summary>
         /// <param name="telop">テロップ</param>
         public static void RefreshTelopWindows(
-            OnePointTelop[] telops)
+            IReadOnlyList<OnePointTelop> telops)
         {
             foreach (var telop in telops)
             {

--- a/ACT.SpecialSpellTimer/OnePointTelopController.cs
+++ b/ACT.SpecialSpellTimer/OnePointTelopController.cs
@@ -195,7 +195,7 @@
         {
             foreach (var log in logLines)
             {
-                foreach (var telop in telops)
+                telops.AsParallel().ForAll(telop =>
                 {
                     var matched = false;
 
@@ -240,7 +240,7 @@
                         }
 
                         // 正規表現マッチ
-                        if (regex != null)
+                        else
                         {
                             var match = regex.Match(log);
                             if (match.Success)
@@ -278,7 +278,7 @@
                     {
                         SpellTimerCore.Default.updateNormalSpellTimerForTelop(telop, telop.ForceHide);
                         SpellTimerCore.Default.notifyNormalSpellTimerForTelop(telop.Title);
-                        continue;
+                        return;
                     }
 
                     // 通常マッチ(強制非表示)
@@ -297,7 +297,7 @@
                     }
 
                     // 正規表現マッチ(強制非表示)
-                    if (regexToHide != null)
+                    else
                     {
                         if (regexToHide.IsMatch(log))
                         {
@@ -311,7 +311,8 @@
                         SpellTimerCore.Default.updateNormalSpellTimerForTelop(telop, telop.ForceHide);
                         SpellTimerCore.Default.notifyNormalSpellTimerForTelop(telop.Title);
                     }
-                }   // end loop telops
+
+                });   // end loop telops
             }
 
             // スペルの更新とサウンド処理を行う

--- a/ACT.SpecialSpellTimer/OnePointTelopTable.cs
+++ b/ACT.SpecialSpellTimer/OnePointTelopTable.cs
@@ -42,9 +42,9 @@
         /// <summary>
         /// データテーブル
         /// </summary>
-        private List<OnePointTelop> table = new List<OnePointTelop>();
+        private readonly List<OnePointTelop> table = new List<OnePointTelop>();
 
-        private OnePointTelop[] enabledTable;
+        private volatile OnePointTelop[] enabledTable;
 
         private DateTime enabledTableTimeStamp;
 
@@ -70,14 +70,15 @@
         /// <summary>
         /// 有効なエントリのリスト
         /// </summary>
-        public OnePointTelop[] EnabledTable
+        public IReadOnlyList<OnePointTelop> EnabledTable
         {
             get
             {
+                var now = DateTime.Now;
                 if (this.enabledTable == null ||
-                    (DateTime.Now - this.enabledTableTimeStamp).TotalSeconds >= 5.0d)
+                    (now - this.enabledTableTimeStamp).TotalSeconds >= 5.0d)
                 {
-                    this.enabledTableTimeStamp = DateTime.Now;
+                    this.enabledTableTimeStamp = now;
                     this.enabledTable = EnabledTableCore;
                 }
 

--- a/ACT.SpecialSpellTimer/SelectJobForm.cs
+++ b/ACT.SpecialSpellTimer/SelectJobForm.cs
@@ -53,7 +53,7 @@
             var jobs = this.JobFilter.Split(',');
 
             this.JobsCheckedListBox.Items.Clear();
-            foreach (var job in Job.GetJobList())
+            foreach (var job in Job.JobList)
             {
                 this.JobsCheckedListBox.Items.Add(
                     job,

--- a/ACT.SpecialSpellTimer/Sound/SoundController.cs
+++ b/ACT.SpecialSpellTimer/Sound/SoundController.cs
@@ -149,7 +149,7 @@
 
                 if (this.EnabledYukkuri)
                 {
-                    ActGlobals.oFormActMain.TTS(source);
+                    Task.Run(() => ActGlobals.oFormActMain.TTS(source));
                 }
                 else
                 {

--- a/ACT.SpecialSpellTimer/SpecialSpellTimerPlugin.cs
+++ b/ACT.SpecialSpellTimer/SpecialSpellTimerPlugin.cs
@@ -59,7 +59,7 @@
             OnePointTelopController.CloseTelops();
 
             FF14PluginHelper.RefreshPlayer();
-            LogBuffer.RefreshPTList();
+            LogBuffer.RefreshPartyList();
             LogBuffer.RefreshPetID();
 
             if (Settings.Default.OverlayVisible)
@@ -246,7 +246,7 @@
                 OnePointTelopController.CloseTelops();
 
                 FF14PluginHelper.RefreshPlayer();
-                LogBuffer.RefreshPTList();
+                LogBuffer.RefreshPartyList();
                 LogBuffer.RefreshPetID();
 
                 if (Settings.Default.OverlayVisible)

--- a/ACT.SpecialSpellTimer/SpecialSpellTimerPlugin.cs
+++ b/ACT.SpecialSpellTimer/SpecialSpellTimerPlugin.cs
@@ -135,6 +135,8 @@
             TabPage pluginScreenSpace,
             Label pluginStatusText)
         {
+            Logger.Begin();
+
             try
             {
                 Logger.Write("Plugin Start.");
@@ -205,6 +207,7 @@
 
                 this.PluginStatusLabel.Text = "Plugin Exited Error";
             }
+            Logger.End();
         }
 
         /// <summary>

--- a/ACT.SpecialSpellTimer/SpellTimerCore.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerCore.cs
@@ -394,7 +394,7 @@
         /// <param name="logLines">ログ</param>
         private void MatchSpells(
             SpellTimer[] spells,
-            string[] logLines)
+            IReadOnlyList<string> logLines)
         {
             foreach (var logLine in logLines)
             {

--- a/ACT.SpecialSpellTimer/SpellTimerCore.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerCore.cs
@@ -223,6 +223,8 @@
                 if (this.RefreshWindowTimer != null &&
                     this.RefreshWindowTimer.IsEnabled)
                 {
+                    Logger.Update();
+
                     // 有効なスペルとテロップのリストを取得する
                     var spellArray = SpellTimerTable.EnabledTable;
                     var telopArray = OnePointTelopTable.Default.EnabledTable;

--- a/ACT.SpecialSpellTimer/SpellTimerCore.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerCore.cs
@@ -8,6 +8,7 @@
     using System.Runtime.InteropServices;
     using System.Text.RegularExpressions;
     using System.Threading;
+    using System.Threading.Tasks;
 
     using ACT.SpecialSpellTimer.Properties;
     using ACT.SpecialSpellTimer.Utility;
@@ -50,9 +51,9 @@
 #endif
 
         /// <summary>
-        /// ログ監視タイマ
+        /// ログポーリングスレッド
         /// </summary>
-        private System.Timers.Timer WatchLogTimer;
+        private Thread logPoller;
 
         /// <summary>
         /// RefreshWindowタイマ
@@ -88,6 +89,8 @@
             set;
         }
 
+        private volatile bool running = false;
+
         /// <summary>
         /// 開始する
         /// </summary>
@@ -111,42 +114,31 @@
             this.RefreshWindowTimer.Tick += this.RefreshWindowTimerOnTick;
             this.RefreshWindowTimer.Start();
 
+            running = true;
             // ログ監視タイマを開始する
-            this.WatchLogTimer = new System.Timers.Timer()
+            logPoller = new Thread(() =>
             {
-                Interval = Settings.Default.LogPollSleepInterval,
-                AutoReset = true,
-            };
-
-            this.WatchLogTimer.Elapsed += (s, e) =>
-            {
-#if DEBUG
-                var sw = Stopwatch.StartNew();
-#endif
-                try
+                Thread.Sleep(TimeSpan.FromSeconds(5));
+                Logger.Write("start log poll");
+                while (running)
                 {
-                    if (this.WatchLogTimer != null &&
-                        this.WatchLogTimer.Enabled)
+                    try
                     {
-                        this.WatchLog();
+                        WatchLog();
+                    }
+                    catch (ThreadAbortException)
+                    {
+                        running = false;
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Write("logPoller error:", ex);
                     }
                 }
-                catch (Exception ex)
-                {
-                    Logger.Write(Translate.Get("SpellTimerRefreshError"), ex);
-                }
-                finally
-                {
-#if DEBUG
-                    sw.Stop();
-                    Debug.WriteLine(
-                        DateTime.Now.ToString("[yyyy-MM-dd HH:mm:ss.fff]") + " " +
-                        "●WatchLog " + sw.Elapsed.TotalMilliseconds.ToString("N4") + "ms");
-#endif
-                }
-            };
+                Logger.Write("end log poll");
+            });
 
-            this.WatchLogTimer.Start();
+            logPoller.Start();
         }
 
         /// <summary>
@@ -154,6 +146,8 @@
         /// </summary>
         public void End()
         {
+            running = false;
+
             // 戦闘分析を開放する
             CombatAnalyzer.Default.Denitialize();
 
@@ -171,11 +165,22 @@
                 this.RefreshWindowTimer = null;
             }
 
-            if (this.WatchLogTimer != null)
+            if (logPoller != null)
             {
-                this.WatchLogTimer.Stop();
-                this.WatchLogTimer.Dispose();
-                this.WatchLogTimer = null;
+                if (logPoller.IsAlive)
+                {
+                    try
+                    {
+                        if (!logPoller.Join(TimeSpan.FromSeconds(5)))
+                        {
+                            logPoller.Abort();
+                        }
+                    }
+                    catch
+                    {
+                    }
+                    logPoller = null;
+                }
             }
 
             // 全てのPanelを閉じる
@@ -217,7 +222,6 @@
                 if (Interlocked.CompareExchange(ref settingsIsValid, VALID, INVALID) == INVALID)
                 {
                     RefreshWindowTimer.Interval = TimeSpan.FromMilliseconds(Settings.Default.RefreshInterval);
-                    WatchLogTimer.Interval = Settings.Default.LogPollSleepInterval;
                 }
 
                 if (this.RefreshWindowTimer != null &&
@@ -316,30 +320,38 @@
             // ACTが起動していない？
             if (ActGlobals.oFormActMain == null)
             {
-                Thread.Sleep(1000);
+                Logger.Write("act not started.");
+                Thread.Sleep(TimeSpan.FromSeconds(3));
                 return;
             }
 
-            // 有効なスペルとテロップのリストを取得する
-            var spellArray = SpellTimerTable.EnabledTable;
-            var telopArray = OnePointTelopTable.Default.EnabledTable;
+            if (this.LogBuffer.nonEmpty())
+            {
+                // 有効なスペルとテロップのリストを取得する
+                var spellArray = Task.Run(() => SpellTimerTable.EnabledTable);
+                var telopArray = Task.Run(() => OnePointTelopTable.Default.EnabledTable);
 
-            // ログを取り出す
-            var logLines = this.LogBuffer.GetLogLines();
+                // ログを取り出す
+                var logLines = Task.Run(() => this.LogBuffer.GetLogLines());
 
-            // テロップとマッチングする
-            OnePointTelopController.Match(
-                telopArray,
-                logLines);
+                if (logLines.Result.Count > 0)
+                {
+                    // テロップとマッチングする
+                    var t1 = Task.Run(() => OnePointTelopController.Match(telopArray.Result, logLines.Result));
 
-            // スペルリストとマッチングする
-            this.MatchSpells(
-                spellArray,
-                logLines);
+                    // スペルリストとマッチングする
+                    var t2 = Task.Run(() => this.MatchSpells(spellArray.Result, logLines.Result));
 
-            // コマンドとマッチングする
-            TextCommandController.MatchCommand(
-                logLines);
+                    // コマンドとマッチングする
+                    var t3 = Task.Run(() => TextCommandController.MatchCommand(logLines.Result));
+
+                    Task.WaitAll(t1, t2, t3);
+
+                    return;
+                }
+            }
+
+            Thread.Sleep(TimeSpan.FromMilliseconds(Settings.Default.LogPollSleepInterval));
         }
 
         /// <summary>
@@ -405,7 +417,7 @@
             foreach (var logLine in logLines)
             {
                 // マッチする？
-                foreach (var spell in spells)
+                spells.AsParallel().ForAll(spell =>
                 {
                     var regex = spell.Regex;
                     var notifyNeeded = false;
@@ -422,7 +434,7 @@
                                 var keyword = spell.KeywordReplaced;
                                 if (string.IsNullOrWhiteSpace(keyword))
                                 {
-                                    continue;
+                                    return;
                                 }
 
                                 // キーワードが含まれるか？
@@ -587,7 +599,7 @@
                         this.updateNormalSpellTimer(spell, false);
                         this.notifyNormalSpellTimer(spell);
                     }
-                }
+                });
                 // end loop spells
             }
 

--- a/ACT.SpecialSpellTimer/SpellTimerCore.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerCore.cs
@@ -229,8 +229,7 @@
                 {
                     Logger.Update();
 
-                    if (SpecialSpellTimerPlugin.ConfigPanel != null &&
-                        SpecialSpellTimerPlugin.ConfigPanel.MonitorTabSelected)
+                    if (SpecialSpellTimerPlugin.ConfigPanel != null)
                     {
                         SpecialSpellTimerPlugin.ConfigPanel.UpdateMonitor();
                     }
@@ -359,7 +358,7 @@
         /// </summary>
         /// <param name="spells">Spell</param>
         private void GarbageSpellPanelWindows(
-            SpellTimer[] spells)
+            IReadOnlyList<SpellTimer> spells)
         {
             if (this.SpellTimerPanels != null)
             {
@@ -411,7 +410,7 @@
         /// <param name="spells">Spell</param>
         /// <param name="logLines">ログ</param>
         private void MatchSpells(
-            SpellTimer[] spells,
+            IReadOnlyList<SpellTimer> spells,
             IReadOnlyList<string> logLines)
         {
             foreach (var logLine in logLines)
@@ -718,7 +717,7 @@
         /// <param name="spells">
         /// 対象のスペル</param>
         private void RefreshSpellPanelWindows(
-            SpellTimer[] spells)
+            IReadOnlyList<SpellTimer> spells)
         {
             var spellsGroupByPanel =
                 from s in spells

--- a/ACT.SpecialSpellTimer/SpellTimerCore.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerCore.cs
@@ -225,6 +225,12 @@
                 {
                     Logger.Update();
 
+                    if (SpecialSpellTimerPlugin.ConfigPanel != null &&
+                        SpecialSpellTimerPlugin.ConfigPanel.MonitorTabSelected)
+                    {
+                        SpecialSpellTimerPlugin.ConfigPanel.UpdateMonitor();
+                    }
+
                     // 有効なスペルとテロップのリストを取得する
                     var spellArray = SpellTimerTable.EnabledTable;
                     var telopArray = OnePointTelopTable.Default.EnabledTable;

--- a/ACT.SpecialSpellTimer/SpellTimerTable.cs
+++ b/ACT.SpecialSpellTimer/SpellTimerTable.cs
@@ -19,7 +19,7 @@
     /// </summary>
     public static class SpellTimerTable
     {
-        private static object lockObject = new object();
+        private static readonly object lockObject = new object();
 
         /// <summary>
         /// SpellTimerデータテーブル
@@ -53,16 +53,17 @@
         /// <summary>
         /// 有効なSpellTimerデータテーブル
         /// </summary>
-        public static SpellTimer[] EnabledTable
+        public static IReadOnlyList<SpellTimer> EnabledTable
         {
             get
             {
                 lock (lockObject)
                 {
+                    var now = DateTime.Now;
                     if (enabledTable == null ||
-                        (DateTime.Now - enabledTableTimeStamp).TotalSeconds >= 5.0d)
+                        (now - enabledTableTimeStamp).TotalSeconds >= 5.0d)
                     {
-                        enabledTableTimeStamp = DateTime.Now;
+                        enabledTableTimeStamp = now;
                         enabledTable = EnabledTableCore;
                     }
 
@@ -98,7 +99,7 @@
 
                     // ジョブフィルタをかける
                     if (player == null ||
-                        string.IsNullOrWhiteSpace(spell.JobFilter))
+                        string.IsNullOrEmpty(spell.JobFilter))
                     {
                         enabledByJob = true;
                     }
@@ -113,7 +114,7 @@
 
                     // ゾーンフィルタをかける
                     if (currentZoneID == 0 ||
-                        string.IsNullOrWhiteSpace(spell.ZoneFilter))
+                        string.IsNullOrEmpty(spell.ZoneFilter))
                     {
                         enabledByZone = true;
                     }
@@ -135,19 +136,22 @@
                 // コンパイル済みの正規表現をセットする
                 foreach (var spell in spellsFilteredJob)
                 {
-                    if (string.IsNullOrWhiteSpace(spell.KeywordReplaced))
+                    if (string.IsNullOrEmpty(spell.KeywordReplaced))
                     {
-                        spell.KeywordReplaced = LogBuffer.MakeKeyword(spell.Keyword);
+                        spell.KeywordReplaced = string.IsNullOrEmpty(spell.Keyword)
+                            ? string.Empty : LogBuffer.MakeKeyword(spell.Keyword);
                     }
 
-                    if (string.IsNullOrWhiteSpace(spell.KeywordForExtendReplaced1))
+                    if (string.IsNullOrEmpty(spell.KeywordForExtendReplaced1))
                     {
-                        spell.KeywordForExtendReplaced1 = LogBuffer.MakeKeyword(spell.KeywordForExtend1);
+                        spell.KeywordForExtendReplaced1 = string.IsNullOrEmpty(spell.KeywordForExtend1)
+                            ? string.Empty : LogBuffer.MakeKeyword(spell.KeywordForExtend1);
                     }
 
-                    if (string.IsNullOrWhiteSpace(spell.KeywordForExtendReplaced2))
+                    if (string.IsNullOrEmpty(spell.KeywordForExtendReplaced2))
                     {
-                        spell.KeywordForExtendReplaced2 = LogBuffer.MakeKeyword(spell.KeywordForExtend2);
+                        spell.KeywordForExtendReplaced2 = string.IsNullOrEmpty(spell.KeywordForExtend2)
+                            ? string.Empty : LogBuffer.MakeKeyword(spell.KeywordForExtend2);
                     }
 
                     if (!spell.RegexEnabled)
@@ -162,11 +166,11 @@
                     }
 
                     // マッチングキーワードの正規表現を生成する
-                    var pattern = !string.IsNullOrWhiteSpace(spell.KeywordReplaced) ?
+                    var pattern = !string.IsNullOrEmpty(spell.KeywordReplaced) ?
                         ".*" + spell.KeywordReplaced + ".*" :
                         string.Empty;
 
-                    if (!string.IsNullOrWhiteSpace(pattern))
+                    if (!string.IsNullOrEmpty(pattern))
                     {
                         if (spell.Regex == null ||
                             spell.RegexPattern != pattern)
@@ -184,11 +188,11 @@
                     }
 
                     // 延長するためのマッチングキーワードの正規表現を生成する1
-                    pattern = !string.IsNullOrWhiteSpace(spell.KeywordForExtendReplaced1) ?
+                    pattern = !string.IsNullOrEmpty(spell.KeywordForExtendReplaced1) ?
                         ".*" + spell.KeywordForExtendReplaced1 + ".*" :
                         string.Empty;
 
-                    if (!string.IsNullOrWhiteSpace(pattern))
+                    if (!string.IsNullOrEmpty(pattern))
                     {
                         if (spell.RegexForExtend1 == null ||
                             spell.RegexForExtendPattern1 != pattern)
@@ -206,11 +210,11 @@
                     }
 
                     // 延長するためのマッチングキーワードの正規表現を生成する2
-                    pattern = !string.IsNullOrWhiteSpace(spell.KeywordForExtendReplaced2) ?
+                    pattern = !string.IsNullOrEmpty(spell.KeywordForExtendReplaced2) ?
                         ".*" + spell.KeywordForExtendReplaced2 + ".*" :
                         string.Empty;
 
-                    if (!string.IsNullOrWhiteSpace(pattern))
+                    if (!string.IsNullOrEmpty(pattern))
                     {
                         if (spell.RegexForExtend2 == null ||
                             spell.RegexForExtendPattern2 != pattern)

--- a/ACT.SpecialSpellTimer/TextCommandController.cs
+++ b/ACT.SpecialSpellTimer/TextCommandController.cs
@@ -1,5 +1,6 @@
 ﻿namespace ACT.SpecialSpellTimer
 {
+    using System.Collections.Generic;
     using System.Media;
     using System.Text.RegularExpressions;
 
@@ -24,7 +25,7 @@
         /// <param name="logLines">
         /// ログ行</param>
         public static void MatchCommand(
-            string[] logLines)
+            IReadOnlyList<string> logLines)
         {
             var commandDone = false;
             foreach (var log in logLines)
@@ -88,7 +89,7 @@
                                 break;
 
                             case "pt":
-                                LogBuffer.RefreshPTList();
+                                LogBuffer.RefreshPartyList();
                                 commandDone = true;
                                 break;
 

--- a/ACT.SpecialSpellTimer/Utility/Logger.cs
+++ b/ACT.SpecialSpellTimer/Utility/Logger.cs
@@ -27,7 +27,7 @@
             {
                 return Path.Combine(
                         Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                        @"anoyetta\ACT\ACT.SpecialSpellTimer.log");
+                        @"anoyetta\ACT\ACT.SpecialSpellTimer." + DateTime.Now.ToString("yyyy-MM") + ".log");
             }
         }
 
@@ -59,6 +59,8 @@
         {
             buffer.Enqueue(new LogItem(null, format, args));
         }
+
+        #region Controll metods
 
         public static void Begin()
         {
@@ -141,6 +143,10 @@
             }
         }
 
+        #endregion
+
+        #region LogItem
+
         private class LogItem
         {
             DateTime logTime;
@@ -163,6 +169,8 @@
                 return cause == null ? log : log + Environment.NewLine + cause.ToString();
             }
         }
+
+        #endregion
 
     }
 }

--- a/ACT.SpecialSpellTimer/Utility/Logger.cs
+++ b/ACT.SpecialSpellTimer/Utility/Logger.cs
@@ -1,44 +1,43 @@
 ﻿namespace ACT.SpecialSpellTimer.Utility
 {
     using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
     using System.IO;
     using System.Text;
+    using System.Threading;
 
     /// <summary>
     /// ログ
     /// </summary>
     public static class Logger
     {
+        private static readonly object lockObject = new object();
+
+        private static Timer flushTimer;
+        private static readonly TimeSpan dueTime = TimeSpan.FromSeconds(10);
+        private static readonly TimeSpan period = TimeSpan.FromSeconds(5);
+
+        private static volatile ConcurrentQueue<LogItem> buffer;
+        private static volatile ConcurrentQueue<string> bufferForFile;
+
+        private static string logFile
+        {
+            get
+            {
+                return Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                        @"anoyetta\ACT\ACT.SpecialSpellTimer.log");
+            }
+        }
+
         /// <summary>
         /// ログを書き込む
         /// </summary>
         /// <param name="text">書き込む内容</param>
-        public static void Write(
-            string text)
+        public static void Write(string text)
         {
-            try
-            {
-                var textToWrite =
-                    "[" + DateTime.Now.ToString("yyyy/MM/dd HH:mm:ss.fff") + "] " +
-                    text;
-
-                if (SpecialSpellTimerPlugin.ConfigPanel != null)
-                {
-                    SpecialSpellTimerPlugin.ConfigPanel.AppendLog(textToWrite);
-                }
-
-                var logFile = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                    @"anoyetta\ACT\ACT.SpecialSpellTimer.log");
-
-                File.AppendAllText(
-                    logFile, 
-                    textToWrite + Environment.NewLine, 
-                    new UTF8Encoding(false));
-            }
-            catch (Exception)
-            {
-            }
+            buffer.Enqueue(new LogItem(null, text, null));
         }
 
         /// <summary>
@@ -46,11 +45,124 @@
         /// </summary>
         /// <param name="text">書き込む内容</param>
         /// <param name="ex">例外情報</param>
-        public static void Write(
-            string text,
-            Exception ex)
+        public static void Write(string text, Exception ex)
         {
-            Write(text + Environment.NewLine + ex.ToString());
+            buffer.Enqueue(new LogItem(ex, text, null));
         }
+
+        /// <summary>
+        /// ログを書き込む
+        /// </summary>
+        /// <param name="format">複合書式設定文字列</param>
+        /// <param name="args">0 個以上の書式設定対象オブジェクトを含んだオブジェクト配列。</param>
+        public static void Write(string format, params object[] args)
+        {
+            buffer.Enqueue(new LogItem(null, format, args));
+        }
+
+        public static void Begin()
+        {
+            lock (lockObject)
+            {
+                buffer = new ConcurrentQueue<LogItem>();
+                bufferForFile = new ConcurrentQueue<string>();
+                if (flushTimer != null)
+                    flushTimer.Dispose();
+                flushTimer = new Timer(ignoreState => Flush(), null, dueTime, period);
+            }
+        }
+
+        public static void End()
+        {
+            lock (lockObject)
+            {
+                if (flushTimer != null)
+                    flushTimer.Dispose();
+                flushTimer = null;
+
+                LogItem item;
+                while (buffer.TryDequeue(out item))
+                    bufferForFile.Enqueue(item.ToString());
+
+                Flush();
+
+                buffer = null;
+                bufferForFile = null;
+            }
+        }
+
+        public static void Update()
+        {
+            if (SpecialSpellTimerPlugin.ConfigPanel == null)
+                return;
+
+            var buf = buffer;
+            var fileBuf = bufferForFile;
+
+            if (buf == null || fileBuf == null || buf.IsEmpty)
+                return;
+
+            LogItem item;
+            while (buf.TryDequeue(out item))
+            {
+                var line = item.ToString();
+                fileBuf.Enqueue(line);
+                try
+                {
+                    SpecialSpellTimerPlugin.ConfigPanel.AppendLog(line);
+                }
+                catch (Exception ex)
+                {
+                    if (!line.Contains("ConfigPanel.AppendLog failed."))
+                        Write("ConfigPanel.AppendLog failed.", ex);
+                }
+            }
+        }
+
+        private static void Flush()
+        {
+            var fileBuf = bufferForFile;
+            if (fileBuf == null || fileBuf.IsEmpty)
+                return;
+
+            lock (lockObject)
+            {
+                var lines = new StringBuilder();
+                string line;
+                while (fileBuf.TryDequeue(out line))
+                    lines.AppendLine(line);
+                try
+                {
+                    File.AppendAllText(logFile, lines.ToString(), new UTF8Encoding(false));
+                }
+                catch (Exception)
+                {
+                }
+            }
+        }
+
+        private class LogItem
+        {
+            DateTime logTime;
+            string text;
+            Exception cause;
+            private object[] args;
+
+            public LogItem(Exception cause, string text, object[] args)
+            {
+                logTime = DateTime.Now;
+                this.cause = cause;
+                this.text = text;
+                this.args = args != null && args.Length == 0 ? null : args;
+            }
+
+            public override string ToString()
+            {
+                var log = "[" + logTime.ToString("yyyy/MM/dd HH:mm:ss.fff") + "] "
+                    + (args == null ? text : string.Format(text, args));
+                return cause == null ? log : log + Environment.NewLine + cause.ToString();
+            }
+        }
+
     }
 }


### PR DESCRIPTION
かなり大きな修正となっています。ｽﾐﾏｾﾝ :bow:

現在、実際に使ってみてエラーなどでないかテスト中ですが、先にPR作成しておきます。
修正内容に指摘などあればコメント下さい、対応します。

## 変更の概要
1. パフォーマンス低下を起こしていた問題を修正しました。
この修正により、処理の遅延に引きずられてACT本体やFF本体にも影響が出ていた問題が修正されています。

2. パフォーマンスを向上させました。
環境依存で劇的な変更が出るほどではありませんが、並列処理を増やしたことで、よりパイスペックなパソコン上での処理速度の向上が見込めるようになりました。(たぶん…)

3. `%appdata%\anoyetta\ACT\` 以下に出力されるログファイル名に年月を加えました。
  変更前 `ACT.SpecialSpellTimer.log`
  変更後 `ACT.SpecialSpellTimer.2016-06.log`
月次でローテートします。過去のログ削除機能はありません。


## 詳細
- 並列処理まわりの問題のあるコードを修正

- ACT本体に登録したイベントハンドラ内でログ処理などを行わないように変更
  - 受け取ったイベント引数をキューに詰めるだけの処理とした

- ログ処理まわりのパフォーマンスの向上
  - 等間隔のタイマーによるログ処理のため、前のログ処理が終わる前に次の処理が発生することがあり、ログの回収部分の同期をとっていることで前のタスクが完了するまで次のタスクがブロックされ、タスクが積まれて行ってしまっていたと思われる問題を修正
    - ログが溜まっている間ループし処理し続けるスレッドを設け、タイマーを用いない実装とした
  - 同期をとるためにlockし後続処理をブロッキングしていたコードのいくつかを非同期コレクションを用いるように変更
  - スペルタイマー/テロップ/コマンドのマッチングそれぞれを並列で行うように変更
  - スペルタイマー/テロップのログ1行毎に行う有効な設定とのマッチング処理を並列で行うように変更

- `ACT.SpecialSpellTIemr.Utility.Logger#Write` に文字列フォーマットの機能追加
- `ACT.SpecialSpellTIemr.Utility.Logger#Write` でブロッキングが発生しないよう変更
  - 一旦キューイングしておき、UIスレッドでの更新処理でモニタータブへ、タイマーでファイルへ書き出すように変更した
  - ファイル書き出しのリソース操作の前にロックしコード上で排他するようにした(念のため)
- 異なる複数のスレッドから同時に呼び出される事が前提の実装へと修正
- ログファイルへのの書き出しを5秒毎に行うように変更
- ログファイルを月次でローテーションするように変更
  - ファイルが大きくなりすぎた場合にパフォーマンス問題に繋がる可能性があるため、リセットされるようにするのが目的
  - 通常日時にするほど大量のログは出ないため、月ごとにしています
- モニタータブへのログの反映を必ずUIスレッドで行うように変更

- その他、ごく僅かにパフォーマンス向上が見込める修正を追加
  - モニタータブを表示していない場合はプレースホルダーの更新を停止するように変更
  - TTSの再生をACT本体に委託する処理を非同期に実行するように変更
  - パーティ変更があったかをログからチェックする判定を並列化
  - ペットジョブ判定を最適化
  - パーティメンバーの置換用プレースホルダーを定数化
- ロジックの変更に伴うレアケースな不具合を修正

また、上記変更に伴う内部的な変更点として、 `ACT.SpecialSpellTimer.LogBuffer` クラスをはじめ、いくつかのクラスの公開メソッドやフィールド名の変更などのリファクタリングを行っています。
(LogBufferクラスは多機能になりすぎているように思えるので機能分割も考えたのですが、目的がずれてしまうのとPRが大きくなりすぎるので、見送りました。 :persevere:)

モニタータブの非選択時に更新を止める変更は、画面上に非表示でもタブが選択されている間は有効になりません。これは、想定済みの動作です。一度設定などを終えてしまえば、ACT起動後にプラグインの設定などを見ることはないと思うので、その際のパフォーマンスを僅かながら向上させることが目的です。