### PR TITLE
パーティメンバーのプレースホルダーの設定を再起動せず反映するように変更

### DIFF
--- a/ACT.SpecialSpellTimer/LogBuffer.cs
+++ b/ACT.SpecialSpellTimer/LogBuffer.cs
@@ -86,7 +86,7 @@
         /// <summary>
         /// パーティメンバの代名詞が有効か？
         /// </summary>
-        private static bool enabledPartyMemberPlaceHolder = Settings.Default.EnabledPartyMemberPlaceholder;
+        private static bool enabledPartyMemberPlaceHolder => Settings.Default.EnabledPartyMemberPlaceholder;
 
         #endregion
 
@@ -265,7 +265,7 @@
                 // パーティに変化あり
                 if (!partyChanged)
                 {
-                    if (enabledPartyMemberPlaceHolder && IsPartyChanged(logLine))
+                    if (IsPartyChanged(logLine))
                     {
                         partyChanged = true;
                     }
@@ -572,6 +572,11 @@
                 }
 
                 placeholderToJobNameDictionaly = newList;
+            }
+            else
+            {
+                partyList = EMPTY_STRING_LIST;
+                placeholderToJobNameDictionaly = EMPTY_STRING_PAIR_MAP;
             }
 
             // 置換後のマッチングキーワードを消去する

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-EN.Designer.cs
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-EN.Designer.cs
@@ -1303,7 +1303,7 @@ namespace ACT.SpecialSpellTimer.resources.strings {
         }
         
         /// <summary>
-        ///   ※ &lt;2&gt; - &lt;8&gt; can be used, however the order may be incorrect. (Requires restart) に類似しているローカライズされた文字列を検索します。
+        ///   ※ &lt;2&gt; - &lt;8&gt; can be used, however the order may be incorrect. に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string PartyMemberNumberExplainLabel {
             get {

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-EN.resx
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-EN.resx
@@ -438,8 +438,8 @@
     <comment>表示するパネルの名前</comment>
   </data>
   <data name="PartyMemberNumberExplainLabel" xml:space="preserve">
-    <value>※ &lt;2&gt; - &lt;8&gt; can be used, however the order may be incorrect. (Requires restart)</value>
-    <comment>※&lt;2&gt;～&lt;8&gt;が使用可能になります。ただし2～8の順序は正しくない場合があります（要再起動）</comment>
+    <value>※ &lt;2&gt; - &lt;8&gt; can be used, however the order may be incorrect.</value>
+    <comment>※&lt;2&gt;～&lt;8&gt;が使用可能になります。ただし2～8の順序は正しくない場合があります</comment>
   </data>
   <data name="PartyPronounLabel" xml:space="preserve">
     <value>Use party member names in matching</value>

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-JP.Designer.cs
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-JP.Designer.cs
@@ -1303,7 +1303,7 @@ namespace ACT.SpecialSpellTimer.resources.strings {
         }
         
         /// <summary>
-        ///   ※&lt;2&gt;～&lt;8&gt;が使用可能になります。ただし2～8の順序は正しくない場合があります（要再起動） に類似しているローカライズされた文字列を検索します。
+        ///   ※&lt;2&gt;～&lt;8&gt;が使用可能になります。ただし2～8の順序は正しくない場合があります。 に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string PartyMemberNumberExplainLabel {
             get {

--- a/ACT.SpecialSpellTimer/resources/strings/Strings-JP.resx
+++ b/ACT.SpecialSpellTimer/resources/strings/Strings-JP.resx
@@ -438,8 +438,8 @@
     <comment>Panel name</comment>
   </data>
   <data name="PartyMemberNumberExplainLabel" xml:space="preserve">
-    <value>※&lt;2&gt;～&lt;8&gt;が使用可能になります。ただし2～8の順序は正しくない場合があります（要再起動）</value>
-    <comment>※ &lt;2&gt; - &lt;8&gt; can be used, however the order may be incorrect. (Requires restart)</comment>
+    <value>※&lt;2&gt;～&lt;8&gt;が使用可能になります。ただし2～8の順序は正しくない場合があります。</value>
+    <comment>※ &lt;2&gt; - &lt;8&gt; can be used, however the order may be incorrect.</comment>
   </data>
   <data name="PartyPronounLabel" xml:space="preserve">
     <value>PTメンバの代名詞を有効にする</value>


### PR DESCRIPTION
常に最新の値で判定するようにし、再起動を不要にしました。
一度設定したら変えることはあまりないと思いますが。

設定の変更後にパーティ変更を検知した場合に、保持しているパーティなどの情報が更新されるので、変更した直後はプレースホルダーは有効にならないです。これは想定している動作です。
インスタンスダンジョンに入る、パーティ構成が変わる、 `/e がパーティに参加しました。` のようなエコーメッセージを流す、コマンドで更新する、などを行うことで反映されます。
(モニタータブで確認できます)